### PR TITLE
Added missing bundle dependency

### DIFF
--- a/application/app/AppKernel.php
+++ b/application/app/AppKernel.php
@@ -28,6 +28,7 @@ class AppKernel extends Kernel
             // FoM bundles
             new FOM\ManagerBundle\FOMManagerBundle(),
             new FOM\UserBundle\FOMUserBundle(),
+            new FOM\CoreBundle\FOMCoreBundle(),
 
             // Mapbender3 bundles
             new Mapbender\CoreBundle\MapbenderCoreBundle(),


### PR DESCRIPTION
Without this dependency, I got InvalidArgumentException: Unable to find template "FOMCoreBundle::skel.html.twig".
