### PR TITLE
Update composer.json

### DIFF
--- a/application/composer.json
+++ b/application/composer.json
@@ -41,7 +41,7 @@
         "friendsofsymfony/jsrouting-bundle": "1.5.x",
         "kriswallsmith/buzz": "v0.15",
         "doctrine/doctrine-fixtures-bundle": "2.3.*",
-        "toooni/fpdf": "dev-master",
+        "setasign/fpdi-fpdf": "dev-master",
         "arsgeografica/signing": "1.1.x",
         "phayes/geophp": "1.x",
         "viscreation/vis-ui.js": "0.0.x",


### PR DESCRIPTION
Old "toooni/fpdf" package seams to be removed by the maintainer.
Anyway the original maintainer is "https://www.setasign.com/", so we migrate to "setasign/fpdi-fpdf" instead of "toooni/fpdf" library.


https://github.com/mapbender/mapbender/issues/423