### PR TITLE
change codemirror to zip because of corrupted tar file error

### DIFF
--- a/application/composer.json
+++ b/application/composer.json
@@ -243,8 +243,8 @@
                 "type": "component",
                 "version": "5.13.4",
                 "dist": {
-                    "url": "https://github.com/codemirror/CodeMirror/archive/5.13.4.tar.gz",
-                    "type": "tar"
+                    "url": "https://github.com/codemirror/CodeMirror/archive/5.13.4.zip",
+                    "type": "zip"
                 },
                 "extra": {
                     "component": {

--- a/application/composer.lock
+++ b/application/composer.lock
@@ -243,8 +243,8 @@
             "name": "components/codemirror",
             "version": "5.13.4",
             "dist": {
-                "type": "tar",
-                "url": "https://github.com/codemirror/CodeMirror/archive/5.13.4.tar.gz",
+                "type": "zip",
+                "url": "https://github.com/codemirror/CodeMirror/archive/5.13.4.zip",
                 "reference": null,
                 "shasum": null
             },


### PR DESCRIPTION
Fix for old corrupted tar file error of codemirror. Changed it to zip.