### PR TITLE
Feature/extra oracle configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v.3.0.6.4
+ - Add oracle database config file
+
 ## v.3.0.6.3 - 2017-07-27
  - Fixed regression for for WMS 1.3.0 support (#529)
  - Fixed regression for WMS Scale hint (#584)

--- a/application/app/config/config.yml
+++ b/application/app/config/config.yml
@@ -1,6 +1,8 @@
 imports:
     - { resource: parameters.yml }
     - { resource: security.yml }
+#Uncomment then next line if you have problems using an oracle database with mapbender.
+#   - { resource: oracle.yml }
 
 framework:
     #esi:             ~

--- a/application/app/config/oracle.yml
+++ b/application/app/config/oracle.yml
@@ -1,0 +1,13 @@
+# Should be used when Oracle Server default environment does not match the Doctrine requirements.
+# The following environment variables are required for the Doctrine default date format:
+# NLS_TIME_FORMAT="HH24:MI:SS"
+# NLS_DATE_FORMAT="YYYY-MM-DD HH24:MI:SS"
+# NLS_TIMESTAMP_FORMAT="YYYY-MM-DD HH24:MI:SS"
+# NLS_TIMESTAMP_TZ_FORMAT="YYYY-MM-DD HH24:MI:SS TZH:TZM
+# See http://www.doctrine-project.org/api/dbal/2.0/class-Doctrine.DBAL.Event.Listeners.OracleSessionInit.html
+
+services:
+  oracle.session.listener:
+    class: Doctrine\DBAL\Event\Listeners\OracleSessionInit
+    tags:
+    - { name: doctrine.event_listener, event: postConnect }

--- a/application/app/config/oracle.yml
+++ b/application/app/config/oracle.yml
@@ -10,4 +10,4 @@ services:
   oracle.session.listener:
     class: Doctrine\DBAL\Event\Listeners\OracleSessionInit
     tags:
-    - { name: doctrine.event_listener, event: postConnect }
+     - { name: doctrine.event_listener, event: postConnect }


### PR DESCRIPTION
Some oracle environments are not compatible with the doctrine defaults. This yml
file will add a service to symfony which will set some oracle environment variables which alter the oracle session, so it will fit the doctrine defaults. To activate this yml you need to uncomment the designated line in the config.yml. https://github.com/mapbender/mapbender/issues/693

Can someone please check if I have used correct indents at least in the yml file  :) 