### PR TITLE
app_dev: ignore bootstrap, skip loadClassCache

### DIFF
--- a/application/web/app_dev.php
+++ b/application/web/app_dev.php
@@ -2,6 +2,8 @@
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Debug\Debug;
+require_once(dirname(__FILE__) . '/../src/ComposerBootstrap.php');
+$usePrebuilt = !ComposerBootstrap::isWindows();
 
 // If you don't want to setup permissions the proper way, just uncomment the following PHP line
 // read http://symfony.com/doc/current/book/installation.html#configuration-and-setup for more information
@@ -17,13 +19,19 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
    exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
 }
 
-$loader = require_once __DIR__.'/../app/bootstrap.php.cache';
+if ($usePrebuilt) {
+    $loader = require_once __DIR__.'/../app/bootstrap.php.cache';
+} else {
+    $loader = require_once __DIR__.'/../app/autoload.php';
+}
 Debug::enable();
 
 require_once __DIR__.'/../app/AppKernel.php';
 
 $kernel = new AppKernel('dev', true);
-$kernel->loadClassCache();
+if ($usePrebuilt) {
+    $kernel->loadClassCache();
+}
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();


### PR DESCRIPTION
... only if not on Windows.
This reduces cases where even in dev mode cache clearing / boostrap rebuilding is requried.
E.g. if you add a new class, run composer install, then remove the class again (or rename it, move to a different namespace), your application can break because of a dangling reference in some of the precompiled / "cached" structures, or it can run stale code which invalidates any tests. This is particularly true when testing temporarily with different symfony component versions, but also affects custom entity and bundle classes.

Current aggressive precompilation behavior requires developers to constantly remember to reclear their caches and rebuild the boostrap. This is counter-intuitive when calling app_dev.

Dev mode usually does not require these aggressive optimizations but should always support easy development.

With the changes in app_dev, it becomes much easier and more intuitive to switch between branches in a local dev environment.

I'm targetting 3.0.5 because updating projects from 3.0.5 to a 3.0.6 is the poster case of the issues resolved here.

I'm excluding Windows because we have observed signficant filesystem performance issues which may still justify running these optimizations even in app_dev.