### PR TITLE
Add mapbender commands as an example to use mapbender commands and a …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v.3.0.6.4
+ - Added new documentation file /doc/mapbender_terminal_commands.md (command line)
  - Add oracle database config file
 
 ## v.3.0.6.3 - 2017-07-27

--- a/doc/mapbender_terminal_commands.md
+++ b/doc/mapbender_terminal_commands.md
@@ -3,10 +3,10 @@ Documentation of the Mapbender terminal commands needed for quick installation a
 
 Since Mapbender has implemented the composer tool, you can do all Composer editing from the console as well. The following commands are a selection that can be done via the console.
 
-If you look at all the commands and need the description, you can go to the page [Doku](https://getcomposer.org/doc/03-cli.md).
+If you look at all the commands and need the description, you can go to the [doc page](https://getcomposer.org/doc/03-cli.md).
 
 # Creating a default composer.json
-The command `init-example` is used to create a composer.json, which is extracted from the bootstrap [Configuration](https://github.com/mapbender/mapbender-starter/blob/release/3.0.6/bootstrap). It is made an adjustment and overwrites the old composer.json a change and re-created. The composer.json is then created in the working directory.
+The command `init-example` is used to create a composer.json, which is extracted from the bootstrap [Configuration](https://github.com/mapbender/mapbender-starter/blob/release/3.0.6/bootstrap). Adjustments are made and the old composer.json is being overwritten and re-created in the working directory.
 
 ```bash
 php composer.phar init-example
@@ -143,7 +143,7 @@ Compiling component files
 
 #### Update without dependencies
 
-If only the dev-require packages are to be updated, then you can optionally specify the parameter `--no-dev`. It disables the installation of require-dev packages.
+If only the non-dev/production packages shall be updated, then you can optionally specify the parameter `--no-dev`. It disables the installation of require-dev packages.
 
 ```bash
 php composer.phar update --no-dev

--- a/doc/mapbender_terminal_commands.md
+++ b/doc/mapbender_terminal_commands.md
@@ -1,0 +1,315 @@
+# Mapbender terminal commands
+Documentation of the Mapbender terminal commands needed for quick installation and updating within Composer.json use.
+
+Since Mapbender has implemented the composer tool, you can do all Composer editing from the console as well. The following commands are a selection that can be done via the console.
+
+If you look at all the commands and need the description, you can go to the page [Doku](https://getcomposer.org/doc/03-cli.md).
+
+# Creating a default composer.json
+The command `init-example` is used to create a composer.json, which is extracted from the bootstrap [Configuration](https://github.com/mapbender/mapbender-starter/blob/release/3.0.6/bootstrap). It is made an adjustment and overwrites the old composer.json a change and re-created. The composer.json is then created in the working directory.
+
+```bash
+php composer.phar init-example
+```
+
+* example:
+
+```text
+application$: bin/composer init-example
+> ComposerBootstrap::checkConfiguration
+
+[Clear cache]
+```
+
+# Dependencies install
+
+The `install` command reads the composer.json file from the current Mapbender directory, resolves the dependencies, and installs them in the vendor directory. The install command is used by Mapbender `bootstrap`, see [Link](https://github.com/mapbender/mapbender-starter/blob/release/3.0.7/bootstrap).
+
+```bash
+php composer.phar install
+```
+If a composer.lock file exists in the current Mapbender directory, it uses the exact versions from the lock file instead of resolving them. The lock file ensures that anyone using the MB library receives and uses the same versions of the dependencies.
+
+If there is no composer.lock file, Composer creates its own lock file but with the version from the reprocessors.
+
+# Dependencies update
+
+The command `update` reads the file composer.json from the current directory, where it processes, updates, removes or installs all dependencies.
+
+```bash
+php composer.phar update
+```
+
+#### Update with optimized order
+
+Optimize the autoloader during the autoloader dump with this extra command:
+
+```bash
+php composer.phar update -o
+```
+
+* example:
+
+```text
+/application$: php composer.phar update -o
+Loading composer repositories with package information
+Updating dependencies (including require-dev)
+Nothing to install or update
+Package components/datatables is abandoned, you should avoid using it. Use bower-asset/datatables instead.
+Package guzzle/guzzle is abandoned, you should avoid using it. Use guzzlehttp/guzzle instead.
+Generating optimized autoload files
+> ComponentInstaller\Installer::postAutoloadDump
+Compiling component files
+> Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::buildBootstrap
+> ComposerBootstrap::installAssets
+
+ Trying to install assets as relative symbolic links.
+
+ --- -------------------------- ------------------ 
+      Bundle                     Method / Error    
+ --- -------------------------- ------------------ 
+  ✔   FrameworkBundle            relative symlink  
+  ✔   FOSJsRoutingBundle         relative symlink  
+  ✔   FOMCoreBundle              relative symlink  
+  ✔   FOMManagerBundle           relative symlink  
+  ✔   FOMUserBundle              relative symlink  
+  ✔   MapbenderCoreBundle        relative symlink  
+  ✔   MapbenderWmcBundle         relative symlink  
+  ✔   MapbenderWmsBundle         relative symlink  
+  ✔   MapbenderManagerBundle     relative symlink  
+  ✔   MapbenderPrintBundle       relative symlink  
+  ✔   MapbenderMobileBundle      relative symlink  
+  ✔   MapbenderDigitizerBundle   relative symlink  
+  ✔   SensioDistributionBundle   relative symlink  
+ --- -------------------------- ------------------ 
+
+ [OK] All assets were successfully installed.                                                                           
+
+> ComposerBootstrap::prepareBinaries
+> Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::installRequirementsFile
+```
+
+#### Update individual or specific packages
+
+To limit the upgrade process to a few or specific packages, you can use the packages that you want to update, specify as such:
+ 
+```bash
+php composer.phar update mapbender/mapbender mapbender/data-source
+```
+
+* example:
+
+```text
+/application$: php composer.phar update mapbender/mapbender mapbender/data-source
+Loading composer repositories with package information                                                                                         Updating dependencies (including require-dev)         Package operations: 0 installs, 1 update, 0 removals
+  - Updating mapbender/mapbender dev-release/3.0.6 (9fde835 => ee7a6bc):  Checking out ee7a6bc1fc
+Package components/datatables is abandoned, you should avoid using it. Use bower-asset/datatables instead.
+Package guzzle/guzzle is abandoned, you should avoid using it. Use guzzlehttp/guzzle instead.
+Writing lock file
+Generating optimized autoload files
+> ComponentInstaller\Installer::postAutoloadDump
+Compiling component files
+> Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::buildBootstrap
+> ComposerBootstrap::installAssets
+
+ Trying to install assets as relative symbolic links.
+
+ --- ----------------------------------- ------------------ 
+      Bundle                              Method / Error    
+ --- ----------------------------------- ------------------ 
+  ✔   FrameworkBundle                     relative symlink  
+  ✔   FOSJsRoutingBundle                  relative symlink  
+  ✔   FOMCoreBundle                       relative symlink  
+  ✔   FOMManagerBundle                    relative symlink  
+  ✔   FOMUserBundle                       relative symlink  
+  ✔   MapbenderCoreBundle                 relative symlink  
+  ✔   MapbenderWmcBundle                  relative symlink  
+  ✔   MapbenderWmsBundle                  relative symlink  
+  ✔   MapbenderManagerBundle              relative symlink  
+  ✔   MapbenderPrintBundle                relative symlink  
+  ✔   MapbenderMobileBundle               relative symlink  
+  ✔   MapbenderDigitizerBundle            relative symlink  
+  ✔   MapbenderRoutingBundle              relative symlink  
+  ✔   MapbenderCoordinatesUtilityBundle   relative symlink  
+  ✔   SensioDistributionBundle            relative symlink  
+ --- ----------------------------------- ------------------ 
+
+ [OK] All assets were successfully installed.                                                                           
+
+> ComposerBootstrap::prepareBinaries
+> Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::installRequirementsFile
+
+```
+
+#### Update without dependencies
+
+If only the dev-require packages are to be updated, then you can optionally specify the parameter `--no-dev`. It disables the installation of require-dev packages.
+
+```bash
+php composer.phar update --no-dev
+```
+
+* example:
+
+```text
+/application$: php composer.phar update --no-dev
+              Loading composer repositories with package information
+              Updating dependencies
+              Nothing to install or update
+              Package operations: 0 installs, 0 updates, 31 removals
+                - Removing webmozart/assert (1.2.0)
+                - Removing texy/texy (v2.4)
+                - Removing sebastian/version (1.0.6)
+                - Removing sebastian/recursion-context (1.0.5)
+                - Removing sebastian/global-state (1.1.1)
+                - Removing sebastian/exporter (1.2.2)
+                - Removing sebastian/environment (1.3.8)
+                - Removing sebastian/diff (1.4.3)
+                - Removing sebastian/comparator (1.2.4)
+                - Removing satooshi/php-coveralls (v0.7.1)
+                - Removing predis/predis (v1.1.1)
+                - Removing phpunit/phpunit-selenium (2.0.3)
+                - Removing phpunit/phpunit-mock-objects (2.3.8)
+                - Removing phpunit/phpunit (4.8.36)
+                - Removing phpunit/php-token-stream (1.4.12)
+                - Removing phpunit/php-timer (1.0.9)
+                - Removing phpunit/php-text-template (1.2.1)
+                - Removing phpunit/php-file-iterator (1.4.5)
+                - Removing phpunit/php-code-coverage (2.2.4)
+                - Removing phpspec/prophecy (1.7.3)
+                - Removing phpdocumentor/type-resolver (0.3.0)
+                - Removing phpdocumentor/reflection-docblock (3.2.2)
+                - Removing phpdocumentor/reflection-common (1.0.1)
+                - Removing phing/phing (2.15.2)
+                - Removing phantomjs/phantomjs (1.8.2)
+                - Removing nette/nette (v2.1.12)
+                - Removing kukulich/fshl (2.1.0)
+                - Removing guzzle/guzzle (v3.9.3)
+                - Removing facebook/webdriver (1.1.3)
+                - Removing apigen/apigen (v2.8.1)
+                - Removing andrewsville/php-token-reflection (1.3.1)
+              Package components/datatables is abandoned, you should avoid using it. Use bower-asset/datatables instead.
+              Generating optimized autoload files
+              > ComponentInstaller\Installer::postAutoloadDump
+              Compiling component files
+              > Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::buildBootstrap
+              > ComposerBootstrap::installAssets
+              
+               Trying to install assets as relative symbolic links.
+              
+               --- -------------------------- ------------------ 
+                    Bundle                     Method / Error    
+               --- -------------------------- ------------------ 
+                ✔   FrameworkBundle            relative symlink  
+                ✔   FOSJsRoutingBundle         relative symlink  
+                ✔   FOMCoreBundle              relative symlink  
+                ✔   FOMManagerBundle           relative symlink  
+                ✔   FOMUserBundle              relative symlink  
+                ✔   MapbenderCoreBundle        relative symlink  
+                ✔   MapbenderWmcBundle         relative symlink  
+                ✔   MapbenderWmsBundle         relative symlink  
+                ✔   MapbenderManagerBundle     relative symlink  
+                ✔   MapbenderPrintBundle       relative symlink  
+                ✔   MapbenderMobileBundle      relative symlink  
+                ✔   MapbenderDigitizerBundle   relative symlink  
+                ✔   SensioDistributionBundle   relative symlink  
+               --- -------------------------- ------------------ 
+              
+               [OK] All assets were successfully installed.                                                                           
+              
+              > ComposerBootstrap::prepareBinaries
+              > Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::installRequirementsFile
+```
+
+# Generate a Mapbender documentation
+
+To locally generate a Mapbender documentation, this command can be used. Such as in the creation of a [Deploy-Mapbender-Version](https://doc.mapbender.org/en/book/development/conventions.html#how-to-build-a-new-mapbender3-build). To set optional parameters, you can add `--help` in the console and a short explanation will be given.
+
+```bash
+php composer.phar docs
+```
+
+* example:
+
+```text
+/application$: php composer.phar docs
+> ComposerBootstrap::genApiDocumentation
+
+[Generate Mapbender 3.0.7.0 API documenation to 'application/web/docs/api']
+ApiGen 2.8.0
+------------
+Scanning
+ /home/XX/Projekte/Mapbender/mapbender-starter-commands/application/fom/src
+ /home/XX/Projekte/Mapbender/mapbender-starter-commands/application/mapbender/src
+ /home/XX/Projekte/Mapbender/mapbender-starter-commands/application/owsproxy/src
+ /home/XX/Projekte/Mapbender/mapbender-starter-commands/application/src
+ /home/XX/Projekte/Mapbender/mapbender-starter-commands/application/vendor/mapbender 
+
+[=========================>                                      ]  39.67%  20MB
+[===============================================================>] 100.00%  28MB
+
+Found 410 classes, 0 constants, 0 functions and other 16 used PHP internal classes
+Documentation for 410 classes, 0 constants, 0 functions and other 16 used PHP internal classes will be generated
+Using template config file /home/XX/Projekte/Mapbender/mapbender-starter-commands/application/vendor/apigen/apigen/templates/bootstrap/config.neon
+Wiping out destination directory
+Generating to directory /home/XX/Projekte/Mapbender/mapbender-starter-commands/application/web/docs/api              [>                                                               ]   1.03%  30MB
+enerating to directory /home/XX/Projekte/Mapbender/mapbender-starter-commands/application/web/docs/api              [>                                                               ]   1.03%  30MB
+The class Symfony\Component\DependencyInjection\ContainerAwareTrait is in use but has not been found in the defined sources.
+WARNING: primary_domain 'php' not found, ignored.
+WARNING: The config value `api_url' has type `str', defaults to `dict'.
+[...]
+```
+
+# Export of Mapbender application
+
+To export the current state of local Mapbender version, you can copy the directory of 'build' function and save them separately. The result is saved in the project directory `dist /`. 
+
+#### Creation of an export build
+
+```bash
+php composer.phar build
+
+```
+
+#### Creating a build/Zip/Tar.gz
+
+In addition, a Zip or Tar.gz file can be created for export.
+
+```bash
+php composer.phar build zip 
+
+php composer.phar build tar.gz
+```
+
+* example:
+
+```text
+application$: php composer.phar build tar.gz
+> ComposerBootstrap::distribute
+
+ Trying to install assets as relative symbolic links.
+
+ --- -------------------------- ------------------ 
+      Bundle                     Method / Error    
+ --- -------------------------- ------------------ 
+  ✔   FrameworkBundle            relative symlink  
+  ✔   FOSJsRoutingBundle         relative symlink  
+  ✔   FOMCoreBundle              relative symlink  
+  ✔   FOMManagerBundle           relative symlink  
+  ✔   FOMUserBundle              relative symlink  
+  ✔   MapbenderCoreBundle        relative symlink  
+  ✔   MapbenderWmcBundle         relative symlink  
+  ✔   MapbenderWmsBundle         relative symlink  
+  ✔   MapbenderManagerBundle     relative symlink  
+  ✔   MapbenderPrintBundle       relative symlink  
+  ✔   MapbenderMobileBundle      relative symlink  
+  ✔   MapbenderDigitizerBundle   relative symlink  
+  ✔   SensioDistributionBundle   relative symlink  
+ --- -------------------------- ------------------ 
+
+ [OK] All assets were successfully installed.                                                                           
+
+Distributed to: /home/XX/Projekte/Mapbender/mapbender-starter-commands/dist/mapbender3-starter-3.0.6.3
+> ComposerBootstrap::build
+27M     /home/XX/Projekte/Mapbender/mapbender-starter-commands/dist/mapbender3-starter-3.0.6.3.tar.gz
+```


### PR DESCRIPTION
…first draft for a developers documentation directory

With this PR I want to introduce a doc directory to the mapbender-starter where we can add some developer-documentation that comes out of our CONTRIBUTING.MD. This documentation is a contrast to the user-documentation in doc.mapbender.org and should be written by the devs as fast and nice as possible, in the suitable MD format (which is not suitable for the user-documentation) and in a directory that can sum other parts of documentation as needed (Branching, Project-Creating, Building, Integrating in Gitlab-CI, etc.)