### PR TITLE
Fix/easier unit tests

### DIFF
--- a/application/app/phpunit.xml
+++ b/application/app/phpunit.xml
@@ -18,8 +18,9 @@
             <directory>../src/*/*Bundle/Tests</directory>
         </testsuite>
         <testsuite name="Mapbender">
-            <directory>../mapbender/src/*/*Bundle/Tests</directory>
-            <directory>../fom/src/*/*Bundle/Tests</directory>
+            <directory>../owsproxy/</directory>
+            <directory>../mapbender/</directory>
+            <directory>../fom/</directory>
         </testsuite>
     </testsuites>
 

--- a/bin/run_tests-dev.sh
+++ b/bin/run_tests-dev.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+APPDIR="$(dirname ${BASH_SOURCE[0]})""/../application"
+pushd $APPDIR >/dev/null
+# use composer-installed phpunit
+# regular phpunit won't really work
+bin/phpunit -c app/ --bootstrap=app/autoload.php --exclude-group=functional "$@"
+popd >/dev/null

--- a/bin/run_tests-dev.sh
+++ b/bin/run_tests-dev.sh
@@ -4,4 +4,8 @@ SCRIPTPATH="${SCRIPTPATH:-${BASH_SOURCE[0]}}"
 SCRIPTDIR="$(dirname ${SCRIPTPATH})"
 # use composer-installed phpunit
 # regular phpunit won't really work
-"${SCRIPTDIR}/../application/bin/phpunit" -c "${SCRIPTDIR}/../application/app/" "--bootstrap=${SCRIPTDIR}/../application/app/autoload.php" --exclude-group=functional "$@"
+"${SCRIPTDIR}/../application/bin/phpunit" \
+  -c "${SCRIPTDIR}/../application/app/" \
+  "--bootstrap=${SCRIPTDIR}/../application/app/autoload.php" \
+  --exclude-group=functional \
+  "$@"

--- a/bin/run_tests-dev.sh
+++ b/bin/run_tests-dev.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-APPDIR="$(dirname ${BASH_SOURCE[0]})""/../application"
-pushd $APPDIR >/dev/null
+SCRIPTPATH="$(readlink ${BASH_SOURCE[0]})"
+SCRIPTPATH="${SCRIPTPATH:-${BASH_SOURCE[0]}}"
+SCRIPTDIR="$(dirname ${SCRIPTPATH})"
 # use composer-installed phpunit
 # regular phpunit won't really work
-bin/phpunit -c app/ --bootstrap=app/autoload.php --exclude-group=functional "$@"
-popd >/dev/null
+"${SCRIPTDIR}/../application/bin/phpunit" -c "${SCRIPTDIR}/../application/app/" "--bootstrap=${SCRIPTDIR}/../application/app/autoload.php" --exclude-group=functional "$@"

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -1,10 +1,22 @@
 #!/bin/bash
 APPDIR="$(dirname ${BASH_SOURCE[0]})""/../application"
-pushd $APPDIR
+pushd $APPDIR >/dev/null
 
 # Start PhantomJS, get PID
 phantomjs --webdriver=9876 --webdriver-logfile=/tmp/ghostdriver.log &
 export PJSID=$!
+
+# kill -0 doesn't do any harm to the process but returns an error
+# exit code if no such process exists >= detect if phantomjs started up
+sleep .2
+kill -0 $PJSID 2>/dev/null
+if [ $? -ne 0 ]; then
+    # we're done here
+    # the invocation should have already written an appropriate error message
+    popd >/dev/null
+    exit 1
+fi
+
 echo Running PhantomJS on port 9876 with PID $PJSID
 
 # Run PHPUnit
@@ -12,5 +24,4 @@ phpunit --stop-on-failure -c app/
 
 # Kill PhantomJS
 kill $PJSID
-
-popd
+popd >/dev/null

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -24,7 +24,6 @@ echo Running PhantomJS on port 9876 with PID $PJSID
 "${SCRIPTDIR}/../application/bin/phpunit" \
   -c "${SCRIPTDIR}/../application/app/" \
   "--bootstrap=${SCRIPTDIR}/../application/app/autoload.php" \
-  --stop-on-failure \
   "$@"
 
 _EXC=$?

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -1,9 +1,6 @@
-#!/bin/sh
-
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-OWD="$(pwd)"
-
-cd "$DIR/../application"
+#!/bin/bash
+APPDIR="$(dirname ${BASH_SOURCE[0]})""/../application"
+pushd $APPDIR
 
 # Start PhantomJS, get PID
 phantomjs --webdriver=9876 --webdriver-logfile=/tmp/ghostdriver.log &
@@ -16,4 +13,4 @@ phpunit --stop-on-failure -c app/
 # Kill PhantomJS
 kill $PJSID
 
-cd $OWD
+popd

--- a/doc/unit-testing.md
+++ b/doc/unit-testing.md
@@ -1,0 +1,59 @@
+# Prerequisites
+
+## Development dependencies installed
+You need to install composer development dependencies. This will not change the versions
+of already installed packages, only add extra packages required to run tests.
+ 
+You need to run
+```sh
+bin/composer install --dev
+```
+from your `application` directory.
+
+You can revert back to a shipping state by running
+```sh
+bin/composer install --no-dev
+```
+
+### Posix + bash + PHP>=5.6
+It might work on gitbash and / or cygwin with some fiddling.
+
+
+# Running choices
+Run all tests, including "functional" browser-simulating tests, by invoking
+```
+bin/run_tests.sh
+```
+
+(that's the top-level bin, _not_ the application/bin)
+
+This will require phantomjs on your path. If it can't invoke phantomjs it will bail and do nothing.
+
+
+Run just the straightforward set of in-process tests by invoking
+```
+bin/run_tests-dev.sh
+```
+This one does not require phantomjs.
+
+Both of these commands can be invoked from any current working directory you want.
+
+You can create a symlink to a project's bin/run_tests-dev.sh somewhere in your path and get
+immediate access from anywhere.
+
+Additional command line arguments are passed through to phpunit. Try
+```
+bin/run_tests-dev.sh --help
+```
+
+# Authoring tests
+By default, application/src (suite "Project") and the mapbender/fom/owsproxy trinity of directories
+are scanned for *Test classes. They can be located anywhere, inside or outside of bundles, phpunit
+will find them.
+
+Please [annotate your tests with `@group`](https://phpunit.de/manual/5.7/en/appendixes.annotations.html#appendixes.annotations.group)
+to appropriately preclassify them as either `unit` or `functional`. Additional groups may be
+stacked on top (a test case can be placed into more than one group).
+
+If one group makes sense for all tests in your test case, you can annotate the class once, and
+all tests within it will inherit the setting. 


### PR DESCRIPTION
`phpunit -c application/app` does not work properly (misses extension, can't print test summary)

`application/bin/phpunit -c application/app` is already quite a mouthful. It does work. It does all the Seleniumy-Pythony "functional test" things though that are great for travis, but an encumbrance for development.

So I made [this](https://github.com/mapbender/mapbender-starter/blob/787fb31a0c4aa57dd20f52d9989fbfa873de1630/bin/run_tests-dev.sh).
It's located kind of weirdly in the very top bin path, because then it won't ship in a package build, even by accident.

If you're in application, you'd have to invoke it as `../bin/run_tests-dev.sh`.

It's symlink aware though. So you can punch a symlink into application/bin, or anywhere really. It'll figure out how / from where it was invoked and adapt all paths accordingly.

Means, you can do a "global" install. Something like this:
```
ron@flake:~/proj/mb305/application/mapbender/src/Mapbender/WmsBundle$ ln -s ~/proj/mb305/bin/run_tests-dev.sh ~/bin/run-tests-mb305
ron@flake:~/proj/mb305/application/mapbender/src/Mapbender/WmsBundle$ run-tests-mb305 
PHPUnit 4.8.36 by Sebastian Bergmann and contributors.

........F.......

Time: 1.59 seconds, Memory: 26.00MB

There was 1 failure:

1) Mapbender\WmsBundle\Tests\Entities\WmsLayerSourceTest::testParentChildInitialization
Failed asserting that null is identical to an object of class "Mapbender\WmsBundle\Entity\WmsLayerSource".

/home/ron/proj/mb305/application/mapbender/src/Mapbender/WmsBundle/Tests/Entities/WmsLayerSourceTest.php:20

FAILURES!
Tests: 16, Assertions: 67, Failures: 1.
```

And finally, you can run your unit tests from anywhere inside or outside the project path.