### PR TITLE
Integrate coordinate utility in mapbender.yml Demo application

### DIFF
--- a/application/app/config/applications/mapbender_user.yml
+++ b/application/app/config/applications/mapbender_user.yml
@@ -140,13 +140,6 @@ parameters:
                         icon: iconPoi
                         label: true
                         target: poi
-                    coordinatesutility-button:
-                        title: 'Coordinates Utility'
-                        tooltip: 'Coordinates Utility'
-                        class: Mapbender\CoreBundle\Element\Button
-                        icon: iconGpsTarget
-                        label: true
-                        target: coordinatesutility
                 content:
                     map:
                         title: Main Map
@@ -332,6 +325,13 @@ parameters:
                         display_type: element
                         auto_activate: false
                         deactivate_on_close: false
+                    coordinatesutility:
+                        title: 'Coordinates Utility'
+                        class: Mapbender\CoordinatesUtilityBundle\Element\CoordinatesUtility
+                        type: element
+                        target: map
+                        srsList: []
+                        addMapSrsList: true                        
                     html-about-mapbender:
                         title: 'About Mapbender'
                         class: Mapbender\CoreBundle\Element\HTMLElement

--- a/application/app/config/applications/mapbender_user.yml
+++ b/application/app/config/applications/mapbender_user.yml
@@ -140,6 +140,13 @@ parameters:
                         icon: iconPoi
                         label: true
                         target: poi
+                    coordinatesutility-button:
+                        title: 'Coordinates Utility'
+                        tooltip: 'Coordinates Utility'
+                        class: Mapbender\CoreBundle\Element\Button
+                        icon: iconGpsTarget
+                        label: true
+                        target: coordinatesutility
                 content:
                     map:
                         title: Main Map
@@ -277,6 +284,28 @@ parameters:
                         target: map
                         body: 'Please take a look at this POI'
                         useMailto: false
+                    coordinatesutility:
+                        title: 'Coordinates Utility'
+                        class: Mapbender\CoordinatesUtilityBundle\Element\CoordinatesUtility
+                        type: dialog
+                        target: map
+                        srsList:
+                            -
+                                name: 'EPSG:31466'
+                                title: '31466'
+                            -
+                                name: 'EPSG:31468'
+                                title: '31468'
+                            -
+                                name: 'EPSG:25832'
+                                title: '25832'
+                            -
+                                name: 'EPSG:25833'
+                                title: '25833'
+                            -
+                                name: 'EPSG:4326'
+                                title: '4326'
+                        addMapSrsList: true
                 sidepane:
                     layertree:
                         title: Layertree

--- a/application/app/config/applications/mapbender_user_basic.yml
+++ b/application/app/config/applications/mapbender_user_basic.yml
@@ -153,6 +153,13 @@ parameters:
                         icon: icon-about
                         label: false
                         class: Mapbender\CoreBundle\Element\AboutDialog
+                    coordinatesutility-button:
+                        title: 'Coordinates Utility'
+                        tooltip: 'Coordinates Utility'
+                        class: Mapbender\CoreBundle\Element\Button
+                        icon: iconGpsTarget
+                        label: false
+                        target: coordinatesutility
                 content:
                     map:
                         title: Main Map
@@ -272,6 +279,28 @@ parameters:
                         position: ['0px', '0px']
                         maximized: true
                         fixed: false
+                    coordinatesutility:
+                        title: 'Coordinates Utility'
+                        class: Mapbender\CoordinatesUtilityBundle\Element\CoordinatesUtility
+                        type: dialog
+                        target: map
+                        srsList:
+                            -
+                                name: 'EPSG:31466'
+                                title: '31466'
+                            -
+                                name: 'EPSG:31468'
+                                title: '31468'
+                            -
+                                name: 'EPSG:25832'
+                                title: '25832'
+                            -
+                                name: 'EPSG:25833'
+                                title: '25833'
+                            -
+                                name: 'EPSG:4326'
+                                title: '4326'
+                        addMapSrsList: true
                 footer:
                     activityindicator:
                         class: Mapbender\CoreBundle\Element\ActivityIndicator


### PR DESCRIPTION
yml-Konfiguration für Koordinaten Utility als Button in Toolbar für die beiden yml-Anwendungen mapbender_user.yml und mapbender_user_basic.yml hinzugefügt

Siehe auch:
[#810](https://github.com/mapbender/mapbender/issues/810)
Gitlab: [#249](https://repo.wheregroup.com/wheregroup/projekt-uebersicht/issues/249)