### PR TITLE
Fix/document installation temp dir

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,27 +14,6 @@ Therefore, we provide a few [guidelines][rules] as an overview for contributors 
 
 Mapbender is based on a [Symfony framework] and uses [composer] to manage external and internal libraries as own [modules][module].
 
-# Installation      
-
-
-
-For development reasons, it is recommended to use Chromium (Chrome) or Firefox.
-
-If you want to log in, you have to use the standard combination (name: root / pw: root). Please change these patterns if you want a secure access.
-
-To stop the server from running, just press ctrl-C or close your console.
-
-That's it! 
-
-*The developer installation is only useful for solo development purposes and should be optimized for production or co-working systems.*
-
-
-## Changing root account password
-From the application directory:
-```sh
-app/console fom:user:resetroot
-```
-
 # Modules
 
 Module is a new part of the [Mapbender] concept, based on [Symfony modularity rules](http://www.symfony.com) 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,61 +17,6 @@ Mapbender is based on a [Symfony framework] and uses [composer] to manage extern
 # Installation      
 
 
-## Cloning project source
-
-### via SSH
-```sh
-git clone git@github.com:mapbender/mapbender-starter.git mapbender-starter
-```
-
-or 
-
-### via HTTP
-
-```sh
-git clone https://github.com/mapbender/mapbender-starter.git mapbender-starter
-```
-
-## Switch to project directory
-```sh
-cd mapbender-starter
-```
-
-## Run bootstrap script 
-
-Running the bootstrap script takes some time to get the required libraries and to prepare the project configurations. Bootstrap saves [Mapbender] starter configurations in a `application/app/db/demo.sqlite` configuration file. After that, a SQLite testing database is created. In the end, the script starts an integrated webserver in your terminal. For more on that, check [start webserver]. Symfony configurations are located under `application/app/config`. 
-
-
-```sh
-sh bootstrap
-```
-
-
-## Bootstrap (first run)
-```sh
-./bootstrap
-```
-
-This command performs the following required setup tasks for you:
-* installs dependencies
-* creates a parameters.yml by copying the bundled parameters.yml.dist
-* performs the necessary database setup (as an sqlite file in `application/app/db/demo.sqlite`)
-* creates a root account
-
-It then continues booting into PHP's development web server, so after
-the setup processes have finished, the installation can be accessed
-on `http://localhost:8000/`.
-
-## Testing webserver (subsequent runs)
-In the application subdirectory, run:
-```sh
-app/console server:run
-```
-
-The URL is shown in the output:
-```sh 
-Server running on http://localhost:8000
-```
 
 For development reasons, it is recommended to use Chromium (Chrome) or Firefox.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,36 +17,6 @@ Mapbender is based on a [Symfony framework] and uses [composer] to manage extern
 # Installation      
 
 
-## Preparing system
-
-To get started with the development you need a PHP interpreter and some additional libraries.
-  
-### Preparing Ubuntu 16.04 
-
-```sh
-sudo apt-get install php7.0 php7.0-xml php7.0-mbstring php7.0-pgsql php7.0-gd php7.0-curl php7.0-cli php7.0-sqlite php7.0-intl php7.0-json sqlite curl openssl php-bz2
-```
-
-### Preparing Ubuntu 14.04 
-
-Activate universe repoisitory:
-
-```sh
-sudo add-apt-repository universe
-```
-
-Update package list:
-
-```sh
-sudo apt-get update
-```
-
-Install php interpreter and modules:
-
-```sh
-sudo apt-get install php5 php5-xml php5-mbstring php5-pgsql php5-gd php5-curl php5-cli php5-sqlite php5-intl sqlite curl openssl bz2
-```
-
 ## Cloning project source
 
 ### via SSH

--- a/README.md
+++ b/README.md
@@ -6,6 +6,45 @@ The [official site](http://mapbender.org/?q=en) contains [documentation](http://
 
 To install Mapbender from this Git-repository, please read the guide of the [Git-based installation](http://doc.mapbender.org/en/book/installation/installation_git.html) ([in German](http://doc.mapbender.org/de/book/installation/installation_git.html)).
 
+## Requirements
+
+At a minimum, Mapbender requires a PHP interpreter and the following php extensions to be installed and enabled:
+* curl
+* gd
+* bz2
+* xml
+* json
+* intl
+* mbstring
+* sqlite
+
+### Ubuntu 16.04
+
+```sh
+sudo apt-get install php7.0 php7.0-xml php7.0-mbstring php7.0-pgsql php7.0-gd php7.0-curl php7.0-cli php7.0-sqlite php7.0-intl php7.0-json sqlite curl openssl php-bz2
+```
+
+### Preparing Ubuntu 14.04
+
+Activate universe repoisitory:
+
+```sh
+sudo add-apt-repository universe
+```
+
+Update package list:
+
+```sh
+sudo apt-get update
+```
+
+Install php interpreter and modules:
+
+```sh
+sudo apt-get install php5 php5-xml php5-mbstring php5-pgsql php5-gd php5-curl php5-cli php5-sqlite php5-intl sqlite curl openssl bz2
+```
+
+
 
 ## Components
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ you can skip the dependency checks etc and directly use:
 app/console server:run
 ```
 
+## Changing root account password
+From the application directory run:
+```sh
+app/console fom:user:resetroot
+```
+
 ## Components
 
 Our code is maintained using git and hosted at Github. We split up our code into several parts:

--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ sudo apt-get install php5 php5-cli openssl bzip2 \
     sqlite curl
 ```
 
+## System configuration
+Make sure your PHP interpreter has explicitly configured temp and uploads directories and that they are writable. In >= PHP5.5,
+there are separate php.ini settings for `sys_temp_dir` and `upload_tmp_dir`.
+PHP <= 5.4 uses the value of `upload_tmp_dir` for both.
+
+Your system most likely has separate php.ini files for cli and web server SAPIs such as mod_php, php-fpm, fcgi etc.
+Make sure to make changes in _all_ php.ini files relevant to your installation.
+
 ## Getting the code
 
 Git clone mapbender-starter via ssh or https at your preference:

--- a/README.md
+++ b/README.md
@@ -63,6 +63,55 @@ sudo apt-get install php5 php5-cli openssl bzip2 \
     sqlite curl
 ```
 
+## Getting the code
+
+Git clone mapbender-starter via ssh or https at your preference:
+```sh
+git clone git@github.com:mapbender/mapbender-starter.git mapbender-starter
+```
+
+or
+
+```sh
+git clone https://github.com/mapbender/mapbender-starter.git mapbender-starter
+```
+
+## Bootstrapping
+Switch to project directory and run ./bootstrap
+```sh
+cd mapbender-starter
+./bootstrap
+```
+
+Running the bootstrap script takes some time to get the required libraries and to prepare the project configurations. Bootstrap saves [Mapbender] starter configurations in a `application/app/db/demo.sqlite` configuration file. After that, a SQLite testing database is created. In the end, the script starts an integrated webserver in your terminal. For more on that, check [start webserver]. Symfony configurations are located under `application/app/config`. 
+
+## Bootstrap (first run)
+```sh
+./bootstrap
+```
+
+This command performs the following required setup tasks for you:
+* installs dependencies
+* creates a parameters.yml by copying the bundled parameters.yml.dist
+* performs the necessary database setup (as an sqlite file in `application/app/db/demo.sqlite`)
+* creates a root account
+
+It then continues booting into PHP's development web server, so after
+the setup processes have finished, the installation can be accessed
+on `http://localhost:8000/`.
+
+## Testing webserver (subsequent runs)
+In the application subdirectory, run:
+```sh
+app/console server:run
+```
+
+The URL is shown in the output:
+```sh
+Server running on http://localhost:8000
+```
+
+
 
 ## Components
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,6 @@ The [official site](http://mapbender.org/?q=en) contains [documentation](http://
 To install Mapbender from this Git-repository, please read the guide of the [Git-based installation](http://doc.mapbender.org/en/book/installation/installation_git.html) ([in German](http://doc.mapbender.org/de/book/installation/installation_git.html)).
 
 
-## Branches
-
-The current version of Mapbender is based on the [release/3.0.6 branch](https://github.com/mapbender/mapbender-starter/tree/release/3.0.5). The master branch will reflect the changes of the [current releases](https://github.com/mapbender/mapbender-starter/releases) while the develop branch might contain new features.
-
-
-
 ## Components
 
 Our code is maintained using git and hosted at Github. We split up our code into several parts:

--- a/README.md
+++ b/README.md
@@ -8,25 +8,40 @@ To install Mapbender from this Git-repository, please read the guide of the [Git
 
 ## Requirements
 
-At a minimum, Mapbender requires a PHP interpreter and the following php extensions to be installed and enabled:
+At a minimum, Mapbender requires OpenSSL, curl, a PHP 5.4 interpreter, bzip2 decompression and the following php extensions to be installed and enabled:
 * curl
 * gd
+* intl
+* mbstring
 * bz2
 * xml
 * json
-* intl
-* mbstring
 * sqlite
+
+You may have to install and enable further extensions at your own discretion if you
+want to use specific database systems.
+
+We also recommend installing an sqlite client so you can inspect the (default) sqlite
+database.
+
+E.g.
 
 ### Ubuntu 16.04
 
 ```sh
-sudo apt-get install php7.0 php7.0-xml php7.0-mbstring php7.0-pgsql php7.0-gd php7.0-curl php7.0-cli php7.0-sqlite php7.0-intl php7.0-json sqlite curl openssl php-bz2
+sudo apt-get install php php-cli openssl bzip2 \
+    php-curl php-gd php-intl php-mbstring \
+    php-bz2 php-xml php-json \
+    php-sqlite php-pgsql php-mysql \
+    sqlite curl
 ```
 
-### Preparing Ubuntu 14.04
 
-Activate universe repoisitory:
+### Ubuntu 14.04
+
+14.04 is similar, but requires activation of the "universe" repository and uses versioned package names ("php5-" instead of "php-").
+
+Activate universe repository:
 
 ```sh
 sudo add-apt-repository universe
@@ -38,12 +53,15 @@ Update package list:
 sudo apt-get update
 ```
 
-Install php interpreter and modules:
+Install packages:
 
 ```sh
-sudo apt-get install php5 php5-xml php5-mbstring php5-pgsql php5-gd php5-curl php5-cli php5-sqlite php5-intl sqlite curl openssl bz2
+sudo apt-get install php5 php5-cli openssl bzip2 \
+    php5-curl php5-gd php5-intl php5-mbstring \
+    php5-xml php5-json \
+    php5-sqlite php5-pgsql php5-mysql
+    sqlite curl
 ```
-
 
 
 ## Components

--- a/README.md
+++ b/README.md
@@ -83,35 +83,26 @@ cd mapbender-starter
 ./bootstrap
 ```
 
-Running the bootstrap script takes some time to get the required libraries and to prepare the project configurations. Bootstrap saves [Mapbender] starter configurations in a `application/app/db/demo.sqlite` configuration file. After that, a SQLite testing database is created. In the end, the script starts an integrated webserver in your terminal. For more on that, check [start webserver]. Symfony configurations are located under `application/app/config`. 
-
-## Bootstrap (first run)
-```sh
-./bootstrap
-```
-
-This command performs the following required setup tasks for you:
-* installs dependencies
+The bootstrap command performs the following required setup tasks for you:
+* installs userland dependencies (via composer)
 * creates a parameters.yml by copying the bundled parameters.yml.dist
 * performs the necessary database setup (as an sqlite file in `application/app/db/demo.sqlite`)
-* creates a root account
+* creates a root account with a default password `root` (which you should change later)
 
-It then continues booting into PHP's development web server, so after
-the setup processes have finished, the installation can be accessed
-on `http://localhost:8000/`.
-
-## Testing webserver (subsequent runs)
-In the application subdirectory, run:
-```sh
-app/console server:run
-```
-
-The URL is shown in the output:
+It then continues booting into PHP's development web server, which is not
+production quality, but allows quick testing. The URL is shown in the output:
 ```sh
 Server running on http://localhost:8000
 ```
 
+We recommend doing this at least once even if you plan on using a proper webserver.
+You can stop the server with a simple Ctrl+C.
 
+The full setup processes is only needed once. If you want to run the development webserver again,
+you can skip the dependency checks etc and directly use:
+```sh
+app/console server:run
+```
 
 ## Components
 


### PR DESCRIPTION
Requirements, installation moves from CONTRIBUTING.md => README.md

Sections cleaned up and contracted (e.g. avoid explicit php7.0-* package names on xenial / bionic where a simple php-* package name works the same).
Package lists have been cross-checked with [Ubuntu package search](https://packages.ubuntu.com/search?suite=trusty&section=all&arch=any&keywords=php5-bzip2&searchon=names).

Add section for configuring temp directory. We've seen a number of issues recently that are artifacts of misconfigured temp dirs, where PHP falls back to a (horrendous) default return of empty string / null from sys_get_temp_dir. The documented approach via php.ini is the most robust and SAPI-independent way to get this working.
