### PR TITLE
Fix/separate bootstrap from dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,19 +97,21 @@ The bootstrap command performs the following required setup tasks for you:
 * performs the necessary database setup (as an sqlite file in `application/app/db/demo.sqlite`)
 * creates a root account with a default password `root` (which you should change later)
 
-It then continues booting into PHP's development web server, which is not
-production quality, but allows quick testing. The URL is shown in the output:
-```sh
-Server running on http://localhost:8000
-```
+The full setup processes is only needed once. If you invoke it again, nothing of consequence will happen.
 
-We recommend doing this at least once even if you plan on using a proper webserver.
-You can stop the server with a simple Ctrl+C.
+## Built-in server
+You can test your freshly bootstrapped Mapbender installation using a built-in development server.
+This is not production quality, and has some known issues processing external requests (such as
+in printing), but it allows some quick testing before you set up a production-grade web server.
 
-The full setup processes is only needed once. If you want to run the development webserver again,
-you can skip the dependency checks etc and directly use:
+The server is started like this:
 ```sh
 app/console server:run
+```
+
+The URL is shown in the output:
+```sh
+Server running on http://localhost:8000
 ```
 
 ## Changing root account password

--- a/bootstrap
+++ b/bootstrap
@@ -5,4 +5,6 @@ echo "# Install composer packages";
 php bin/composer install -o
 php bin/composer init-example
 php app/console assets:install --symlink --relative
-php app/console server:run
+echo Bootstrap finished!
+echo If you want to run the builtin development server, run:
+echo php app/console server:run

--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -2,4 +2,6 @@ cd application
 php bin/composer install -o
 php bin/composer init-example
 php app/console assets:install
-php app/console server:run
+echo Bootstrap finished!
+echo If you want to run the builtin development server, run:
+echo php app/console server:run


### PR DESCRIPTION
Bootstrap is now the only documented way to perform basic setup post-checkout.

Bootstrap behaviour is however incompatible with automated build systems, because it runs into the testing web server, which needs to be Ctrl+Ced / otherwise killed.

This pull removes web server invokation from bootstrap, but adds echoing of web server start instructions for users who have relied on this behavior so far.

README.md has also been updated to reflect this change.