### PR TITLE
coordinatesutility only once - deleted in content

### DIFF
--- a/application/app/config/applications/mapbender_user.yml
+++ b/application/app/config/applications/mapbender_user.yml
@@ -277,28 +277,6 @@ parameters:
                         target: map
                         body: 'Please take a look at this POI'
                         useMailto: false
-                    coordinatesutility:
-                        title: 'Coordinates Utility'
-                        class: Mapbender\CoordinatesUtilityBundle\Element\CoordinatesUtility
-                        type: dialog
-                        target: map
-                        srsList:
-                            -
-                                name: 'EPSG:31466'
-                                title: '31466'
-                            -
-                                name: 'EPSG:31468'
-                                title: '31468'
-                            -
-                                name: 'EPSG:25832'
-                                title: '25832'
-                            -
-                                name: 'EPSG:25833'
-                                title: '25833'
-                            -
-                                name: 'EPSG:4326'
-                                title: '4326'
-                        addMapSrsList: true
                 sidepane:
                     layertree:
                         title: Layertree


### PR DESCRIPTION
* coordinatesutility was added twice in content and in sidepane
* it caused an error in the imported application in the database (message coordinatesutility target element is not defined
* deleted the configuration in content (for your info mapbender_user_basic has coordinatesutility in content which is triggered by a button)