### PR TITLE
Updated README.md links to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Mapbender is a web based geoportal framework.
 
-The [official site](http://mapbender.org/?q=en) contains [documentation](http://mapbender.org/?q=en/documentation) and [installation information](http://doc.mapbender.org/en/book/installation.html) ([also available in German](http://doc.mapbender.org/de/book/installation.html)).
+The [official site](http://mapbender.org/?q=en) contains [documentation](http://mapbender.org/?q=en/documentation) and [installation information](https://doc.mapbender.org/en/installation.html) ([also available in German](https://doc.mapbender.org/de/installation.html)).
 
 To install Mapbender from this Git-repository, please read the guide of the [Git-based installation](http://doc.mapbender.org/en/book/installation/installation_git.html) ([in German](http://doc.mapbender.org/de/book/installation/installation_git.html)).
 


### PR DESCRIPTION
On behalf of @marcelnormann.  
This updates URLs in Readme to https.  
This is a release/3.0.6 base with changes not applicable to master (composer.lock bumps, other documentation updates that had to be cherry-picked the other way and are practically already in both branches).  
This explains the merge target.

The isolated README.md change will be cherry-picked onto master.
