### PR TITLE
Fix automation errors

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,6 +33,9 @@ package:
 release:
   stage: release
   except:
+    # If you want to auto-tag your project repository, comment / remove the next line
+    # This is no longer desirable default behaviour for the main Mapbender project
+    - /./
     - tags
     - /^feature\/.*$/
     - /^(fix|hotfix)\/.*$/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,8 +3,8 @@ image: wg-runner/php7
 before_script:
   - cd application
   - export PROJECT_NAME=$(bin/composer project-name)
-  - export NEXT_VERSION_SHORT=$(bin/composer version git next-revision v)
-  - export NEXT_VERSION=$(bin/composer version git next-revision)-$(git rev-parse --short HEAD)
+  - export NEXT_VERSION_SHORT=$(bin/composer version git v)
+  - export NEXT_VERSION=$(bin/composer version git)-$(git rev-parse --short HEAD)
   - export REVISION_TAG=v${NEXT_VERSION_SHORT}
 
 stages:

--- a/application/src/ComposerBootstrap.php
+++ b/application/src/ComposerBootstrap.php
@@ -303,6 +303,10 @@ class ComposerBootstrap
                     // Grab minor version from most recent git tag
                     // most recent tag name on current branch with no decoration
                     $currentTag = trim(@shell_exec('git describe --tags --abbrev=0 ' . escapeshellarg($branch))) ?: null;
+                    if (!$currentTag) {
+                        fwrite(STDERR, "WARNING: git describe failed, on {$branch}, trying again on origin/{$branch}");
+                        $currentTag = trim(@shell_exec('git describe --tags --abbrev=0 ' . escapeshellarg("origin/{$branch}"))) ?: null;
+                    }
                     if ($currentTag) {
                         // remove last number, possible 'RC-' prefix
                         $tagBaseVersion = preg_replace('#[-.]\d+((-?RC-?)?\d+)?$#', '', $currentTag);

--- a/application/src/ComposerBootstrap.php
+++ b/application/src/ComposerBootstrap.php
@@ -313,9 +313,13 @@ class ComposerBootstrap
                 // extract only the final group of consecutive digits as "revisions"
                 $revisions = preg_filter('#(^.{' . (strlen($tagPrefix) + 1) . '})(\S+)#sm', '$2', $matchingTags);
                 natsort($revisions);
-
-                $lastRevision = count($revisions) ? intval(end($revisions)) : -1;
-                $nextRevision = $lastRevision + 1;
+                $nextRevision = 0;
+                foreach (array_reverse($revisions) as $revision) {
+                    if (false === strpos('RC', $revision)) {
+                        $nextRevision = intval($revision) + 1;
+                        break;
+                    }
+                }
                 echo "${projectVersion}.${nextRevision}\n";
             }
         }

--- a/application/src/ComposerBootstrap.php
+++ b/application/src/ComposerBootstrap.php
@@ -284,9 +284,9 @@ class ComposerBootstrap
                 "   bin/composer run git-current [tag-prefix]",
                 "       Prints the latest revision tag. Falls back to '0.0.0.0' if the repository is not"
                 . " yet tagged at all.",
-                "   bin/composer run git-next [tag-prefix]",
+                "   bin/composer run version git-next [tag-prefix]",
                 "       Prints a proposed next, unused tag.",
-                "   bin/composer run git [tag-prefix]",
+                "   bin/composer run version git [tag-prefix]",
                 "       Deprecated alias for 'git-next'.",
                 "",
                 "Both 'git-current' and 'git-next' inspect current branch name (if it looks like a version)"

--- a/application/src/ComposerBootstrap.php
+++ b/application/src/ComposerBootstrap.php
@@ -302,11 +302,17 @@ class ComposerBootstrap
                 } else {
                     // Grab minor version from most recent git tag
                     // most recent tag name on current branch with no decoration
-                    $currentTag = trim(`git describe --tags --abbrev=0 {$branch}`);
-                    // remove last number, possible 'RC-' prefix
-                    $tagBaseVersion = preg_replace('#[-.]\d+((-?RC-?)?\d+)?$#', '', $currentTag);
-                    // remove 'tagPrefix' prefix
-                    $projectMinorVersion = substr($tagBaseVersion, strlen($tagPrefix));
+                    $currentTag = trim(@shell_exec('git describe --tags --abbrev=0 ' . escapeshellarg($branch))) ?: null;
+                    if ($currentTag) {
+                        // remove last number, possible 'RC-' prefix
+                        $tagBaseVersion = preg_replace('#[-.]\d+((-?RC-?)?\d+)?$#', '', $currentTag);
+                        // remove 'tagPrefix' prefix
+                        $projectMinorVersion = substr($tagBaseVersion, strlen($tagPrefix));
+                    } else {
+                        $fallback = '0.0.0';
+                        fwrite(STDERR, "Current commit does not trace back to any tag, using {$fallback} as a minor version\n");
+                        $projectMinorVersion = $fallback;
+                    }
                 }
 
                 $notProjectNames = array(

--- a/application/src/ComposerBootstrap.php
+++ b/application/src/ComposerBootstrap.php
@@ -275,8 +275,35 @@ class ComposerBootstrap
      */
     public static function displayVersion(Event $e)
     {
-        $defaults = array('composer', '');
         $args = $e->getArguments();
+        if (array_intersect(array('--help', '-h', 'help'), $args)) {
+            echo implode("\n", array(
+                "Usage:",
+                "   bin/composer run version composer",
+                "       Displays root package version as defined in composer.json",
+                "   bin/composer run git-current [tag-prefix]",
+                "       Prints the latest revision tag. Falls back to '0.0.0.0' if the repository is not"
+                . " yet tagged at all.",
+                "   bin/composer run git-next [tag-prefix]",
+                "       Prints a proposed next, unused tag.",
+                "   bin/composer run git [tag-prefix]",
+                "       Deprecated alias for 'git-next'.",
+                "",
+                "Both 'git-current' and 'git-next' inspect current branch name (if it looks like a version)"
+                - " and / or tags starting with the optional <tag-prefix> when looking for minor"
+                . " versions.",
+                "",
+                "The printed tag DOES NOT start with <tag-prefix>. If you want the prefix, you have to"
+                . " re-add it yourself. This is useful if you want to 'mirror' tags from Github in your"
+                . " fork, using a different prefix.",
+                "E.g. you can transpose the current Github tag, assuming v3.0.7.4, into a gh3.0.7.4 with (bash):",
+                "   _MIRROR_TAG=\"gh\"\"$(bin/composer run version git-current v)\"",
+                "",
+                "",
+            ));
+            exit(0);
+        }
+        $defaults = array('composer', '');
         if (count($args) >= 2 && ($args[1] == 'next-revision' || $args[1] == 'minor')) {
             fwrite(STDERR, "WARNING: second argument {$args[1]} is redundant, please update your scripts\n");
             $args = array_merge(array($args[0]), array_slice($args, 2));

--- a/application/src/ComposerBootstrap.php
+++ b/application/src/ComposerBootstrap.php
@@ -299,7 +299,7 @@ class ComposerBootstrap
                 // most recent tag name on current branch with no decoration
                 $currentTag = trim(@shell_exec('git describe --tags --abbrev=0 ' . escapeshellarg($branch))) ?: null;
                 if (!$currentTag) {
-                    fwrite(STDERR, "WARNING: git describe failed, on {$branch}, trying again on origin/{$branch}");
+                    fwrite(STDERR, "WARNING: git describe failed, on {$branch}, trying again on origin/{$branch}\n");
                     $currentTag = trim(@shell_exec('git describe --tags --abbrev=0 ' . escapeshellarg("origin/{$branch}"))) ?: null;
                 }
                 if ($currentTag) {
@@ -340,7 +340,8 @@ class ComposerBootstrap
                     $matchTagPrefix .= $branchNameParts[0];
                 }
                 $matchTagPrefix .= $projectMinorVersion;
-                $matchingTags = array_filter(explode("\n", trim(`git tag -l '${matchTagPrefix}*'`)));
+                $escapedMatchTagPattern = escapeshellarg("{$matchTagPrefix}*");
+                $matchingTags = array_filter(explode("\n", trim(`git tag -l -- $escapedMatchTagPattern`)));
                 if ($matchingTags) {
                     // extract only the final group of consecutive digits as "revisions"
                     $revisions = preg_filter('#(^.{' . (strlen($matchTagPrefix) + 1) . '})(\S+)#sm', '$2', $matchingTags);

--- a/application/src/ComposerBootstrap.php
+++ b/application/src/ComposerBootstrap.php
@@ -340,10 +340,14 @@ class ComposerBootstrap
                     $matchTagPrefix .= $branchNameParts[0];
                 }
                 $matchTagPrefix .= $projectMinorVersion;
-                $matchingTags = explode("\n", trim(`git tag -l '${matchTagPrefix}*'`));
+                $matchingTags = array_filter(explode("\n", trim(`git tag -l '${matchTagPrefix}*'`)));
+                if ($matchingTags) {
+                    // extract only the final group of consecutive digits as "revisions"
+                    $revisions = preg_filter('#(^.{' . (strlen($matchTagPrefix) + 1) . '})(\S+)#sm', '$2', $matchingTags);
+                } else {
+                    $revisions = array();
+                }
 
-                // extract only the final group of consecutive digits as "revisions"
-                $revisions = preg_filter('#(^.{' . (strlen($matchTagPrefix) + 1) . '})(\S+)#sm', '$2', $matchingTags);
                 natsort($revisions);
                 $nextRevision = 0;
                 foreach (array_reverse($revisions) as $revision) {

--- a/application/src/ComposerBootstrap.php
+++ b/application/src/ComposerBootstrap.php
@@ -349,11 +349,20 @@ class ComposerBootstrap
                 }
 
                 natsort($revisions);
+
                 $nextRevision = 0;
                 foreach (array_reverse($revisions) as $revision) {
-                    if (false === strpos('RC', $revision)) {
+                    if (false === strpos($revision, 'RC')) {
                         $nextRevision = intval($revision) + 1;
                         break;
+                    } else {
+                        $preRcRevision = intval($revision);
+                        if (!in_array($preRcRevision, $revisions)) {
+                            // we have an RC version as the highest, and there is no corresponding non-RC
+                            // => "upgrade" the RC patch level directly to a non-RC patch level
+                            $nextRevision = $preRcRevision;
+                            break;
+                        }
                     }
                 }
                 echo "${projectMinorVersion}.${nextRevision}\n";

--- a/application/src/ComposerBootstrap.php
+++ b/application/src/ComposerBootstrap.php
@@ -275,7 +275,7 @@ class ComposerBootstrap
      */
     public static function displayVersion(Event $e)
     {
-        $defaults = array('composer', 'minor', '-');
+        $defaults = array('composer', 'minor', '');
         list($vendorType, $versionTime, $versionGlue) = array_replace($defaults, $e->getArguments());
         if ($vendorType == "composer") {
             /** @var \Composer\Package\RootPackage $rootPackage */


### PR DESCRIPTION
[Gitlab CI script invokes a `composer version git next-revision v`](https://github.com/mapbender/mapbender-starter/blob/v3.0.7.4/.gitlab-ci.yml#L6) which lands [here in ComposerBootstrap](https://github.com/mapbender/mapbender-starter/blob/v3.0.7.4/application/src/ComposerBootstrap.php#L288) and immediately fails if the current branch name is not something/something, and even if it is, would still eventually fail if the second something doesn't prefix-match a git tag.

Change works for arbitrary branch names (including, obviously 'master').  
Change still detects und uses something/3.0.6 as a base version indicator, but in absence of such names, falls back to git version tag as the leading source of version information.  
Change detects if the 'next' tag contains no actual changes and re-prints the current version.  
Change adds a `git-current` mode of operation that always prints the current version.  
Change adds detection for `RC` suffixes on tag names, and alters its suggestions for the next tag accordingly. If an RC is the newest version, the suggested tag is the same version just without the RC suffix.  
Change adds command line help; the operation is a bit obscure and warrants documentation.

Finally, one really important point: change disables automatic tagging in the Gitlab CI script by default by [adding an always-matching except clause](https://github.com/mapbender/mapbender-starter/blob/fix/automation-errors/.gitlab-ci.yml#L36). If you need this behaviour, you can restore it by removing that one line. It's not safe enough to remain on by default.

Examples:
```
application$ git branch | grep -P '^\*'
* fix/automation-errors
application$ bin/composer run version git-next v
3.0.7.5
application$ bin/composer run version git-current v
3.0.7.4
application$ git checkout -b release/15.100.2
Switched to a new branch 'release/15.100.2'
application$ bin/composer run version git-next v
15.100.2.0       ## version-ish branch name detected

application$ git checkout -b nondescript     ## branch name with no slash and no special meaning
Switched to a new branch 'nondescript'
application$ bin/composer run version git-next v
3.0.7.5             ## falls back to tags
```


```
## RC tag treatment
application$ git tag Bob3.4.5.2
application$ git tag Bob3.4.5.3-RC1
application$ bin/composer run version git-current Bob && bin/composer run git-next Bob
3.4.5.3      ## current same as next because nothing follows RC
3.4.5.3      

application$ git tag Bob3.4.5.3
application$ bin/composer run version git-current Bob && bin/composer run version git-next Bob
3.4.5.3
3.4.5.4      ## next pushed up because current is out of RC   
```
Added help:
```
application$ bin/composer run version help | fold -w 80
> ComposerBootstrap::displayVersion
Usage:
   bin/composer run version composer
       Displays root package version as defined in composer.json
   bin/composer run version git-current [tag-prefix]
       Prints the latest revision tag. Falls back to '0.0.0.0' if the repository
 is not yet tagged at all.
   bin/composer run version git-next [tag-prefix]
       Prints a proposed next, unused tag.
   bin/composer run version git [tag-prefix]
       Deprecated alias for 'git-next'.

0 versions.

The printed tag DOES NOT start with <tag-prefix>. If you want the prefix, you ha
ve to re-add it yourself. This is useful if you want to 'mirror' tags from Githu
b in your fork, using a different prefix.
E.g. you can transpose the current Github tag, assuming v3.0.7.4, into a gh3.0.7
.4 with (bash):
   _MIRROR_TAG="gh""$(bin/composer run version git-current v)"
```
