### PR TITLE
Fix/ci errors

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,7 @@ package:
     - tags
   script:
     - bin/composer install -o --no-dev --ignore-platform-reqs --no-scripts --no-suggest
+    - bin/composer run build-bootstrap
     - bin/composer init-example
     - bin/composer gen-user-docs
     - bin/composer "build" "tar.gz" "${PROJECT_NAME}" "${NEXT_VERSION}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ package:
     - bin/composer "build" "zip" "${PROJECT_NAME}" "${NEXT_VERSION}"
 
   artifacts:
-    name: "$(git describe --tags)-$(git rev-parse --short HEAD)"
+    name: "$(git describe --tags HEAD)"
     paths:
       - "${CI_PROJECT_DIR}/dist/*.tar.gz"
       - "${CI_PROJECT_DIR}/dist/*.zip"

--- a/application/src/ComposerBootstrap.php
+++ b/application/src/ComposerBootstrap.php
@@ -418,8 +418,9 @@ class ComposerBootstrap
         }
 
         if ($vendorType == "git") {
-            list($projectName, $projectVersion) = explode("/", self::getGitBranchName());
-            echo $projectName . "\n";
+            $branchNameParts = explode('/', self::getGitBranchName());
+            $firstPart = implode('', array_slice($branchNameParts, 0, 1));
+            echo "{$firstPart}\n";
         }
     }
 


### PR DESCRIPTION
Fixes initial composer install to skip (failing) asset setup.  
Adds build-bootstrap to prevent app/console fatalities due to missing bootstrap.php.cache, which arise from previous change.  
Fixes composer project-name failing on branch names without slash (such as 'master'). This fixes collateral tar errors. Empty project-name output produces an artifact name with a leading dash, which tar complains about as an unknown option.  
Removes the repeated second short commit hash from the artifact name. C.f.:
```sh
$ echo "$(git describe --tags)-$(git rev-parse --short HEAD)"
v3.0.7.7-14-g3fd1b33-3fd1b33
$ echo "$(git describe --tags HEAD)"
v3.0.7.7-14-g3fd1b33
```
The short commit hash `3fd1b33` _is_ _part_ _of_ the describe output anyway.

