### PR TITLE
delete api.mapbender.org + fix doc.mapbender.org

### DIFF
--- a/application/composer.json
+++ b/application/composer.json
@@ -9,8 +9,7 @@
         "email":        "mapbender@osgeo.org",
         "issues":       "https://github.com/mapbender/mapbender/issues",
         "source":       "https://github.com/mapbender/mapbender-starter",
-        "docs":         "http://doc.mapbender3.org/",
-        "api-docs":     "http://api.mapbender3.org/",
+        "docs":         "http://doc.mapbender.org/",
         "forum":        "http://osgeo-org.1560.x6.nabble.com/Mapbender-f4217602.html",
         "twitter":      "https://twitter.com/mapbender",
         "user-list":    "https://lists.osgeo.org/pipermail/mapbender_users/"


### PR DESCRIPTION
* api.mapbender.org is not available anymore
* doc.mapbender.org without 3