### PR TITLE
Fix/layertitle osm demo

### DIFF
--- a/application/app/config/applications/mapbender_mobile.yml
+++ b/application/app/config/applications/mapbender_mobile.yml
@@ -29,7 +29,7 @@ parameters:
                         url: https://osm-demo.wheregroup.com/service
                         version: 1.3.0
                         layers:
-                            30: { name: osm,    title : Germany OSM Demo WhereGroup,  visible: true }
+                            30: { name: osm,    title : OSM Demo WhereGroup,  visible: true }
                         info_format: text/html
                         visible: true
                         format: image/png
@@ -43,7 +43,7 @@ parameters:
                         url: https://osm-demo.wheregroup.com/service
                         version: 1.3.0
                         layers:
-                            30: { name: osm,    title : Germany OSM Demo WhereGroup,  visible: true }
+                            30: { name: osm,    title : OSM Demo WhereGroup,  visible: true }
                         info_format: text/html
                         visible: true
                         format: image/png

--- a/application/app/config/applications/mapbender_user.yml
+++ b/application/app/config/applications/mapbender_user.yml
@@ -33,7 +33,7 @@ parameters:
                         url: https://osm-demo.wheregroup.com/service
                         version: 1.3.0
                         layers:
-                            30: { name: osm,    title : Germany OSM Demo WhereGroup,  visible: true }
+                            30: { name: osm,    title : OSM Demo WhereGroup,  visible: true }
                         info_format: text/html
                         visible: true
                         format: image/png
@@ -47,7 +47,7 @@ parameters:
                         url: https://osm-demo.wheregroup.com/service
                         version: 1.3.0
                         layers:
-                            40: { name: osm,    title : Germany OSM Demo WhereGroup,  visible: true }
+                            40: { name: osm,    title : OSM Demo WhereGroup,  visible: true }
                         tiled: false
                         format: image/png
                         transparent: true

--- a/application/app/config/applications/mapbender_user_basic.yml
+++ b/application/app/config/applications/mapbender_user_basic.yml
@@ -47,7 +47,7 @@ parameters:
                         url: https://osm-demo.wheregroup.com/service
                         version: 1.3.0
                         layers:
-                            30: { name: osm,    title : Germany OSM Demo WhereGroup,  visible: true }
+                            30: { name: osm,    title : OSM Demo WhereGroup,  visible: true }
                         info_format: text/html
                         visible: true
                         format: image/png
@@ -61,7 +61,7 @@ parameters:
                         url: https://osm-demo.wheregroup.com/service
                         version: 1.3.0
                         layers:
-                            40: { name: osm,    title : Germany OSM Demo WhereGroup,  visible: true }
+                            40: { name: osm,    title : OSM Demo WhereGroup,  visible: true }
                         tiled: false
                         format: image/png
                         transparent: true


### PR DESCRIPTION
@astroidex noticed that the layertitle "Germany OSM Demo WhereGroup" should be changed, because the layer represents the whole world.
I changed the title to "OSM Demo WhereGroup".

https://github.com/mapbender/mapbender/issues/1188