### PR TITLE
Prune/sensio/distribution bundle

### DIFF
--- a/application/app/console
+++ b/application/app/console
@@ -8,7 +8,6 @@
 set_time_limit(0);
 
 require_once(dirname(__FILE__) . '/autoload.php');
-require_once(dirname(__FILE__) . '/bootstrap.php.cache');
 require_once(dirname(__FILE__) . '/AppKernel.php');
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;

--- a/application/composer.json
+++ b/application/composer.json
@@ -54,15 +54,10 @@
         "laminas/laminas-eventmanager": ">=3.3.0"
     },
     "scripts": {
-        "build-bootstrap": [
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap"
-        ],
         "post-install-cmd": [
             "@composer dump-autoload",
             "ComposerBootstrap::clearCache",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
             "@update-assets",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile"
         ],
         "post-update-cmd": [
             "@post-install-cmd"

--- a/application/composer.json
+++ b/application/composer.json
@@ -57,7 +57,7 @@
         "post-install-cmd": [
             "@composer dump-autoload",
             "ComposerBootstrap::clearCache",
-            "@update-assets",
+            "@update-assets"
         ],
         "post-update-cmd": [
             "@post-install-cmd"

--- a/application/composer.lock
+++ b/application/composer.lock
@@ -5382,62 +5382,6 @@
     ],
     "packages-dev": [
         {
-            "name": "composer/ca-bundle",
-            "version": "1.2.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "95c63ab2117a72f48f5a55da9740a3273d45b7fd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/95c63ab2117a72f48f5a55da9740a3273d45b7fd",
-                "reference": "95c63ab2117a72f48f5a55da9740a3273d45b7fd",
-                "shasum": ""
-            },
-            "require": {
-                "ext-openssl": "*",
-                "ext-pcre": "*",
-                "php": "^5.3.2 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8",
-                "psr/log": "^1.0",
-                "symfony/process": "^2.5 || ^3.0 || ^4.0 || ^5.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\CaBundle\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
-            "keywords": [
-                "cabundle",
-                "cacert",
-                "certificate",
-                "ssl",
-                "tls"
-            ],
-            "time": "2020-04-08T08:27:21+00:00"
-        },
-        {
             "name": "ircmaxell/password-compat",
             "version": "v1.0.4",
             "source": {

--- a/application/composer.lock
+++ b/application/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dd64a7c3da522a45a106990b71078e24",
+    "content-hash": "9f0f850e3d30e36c247597a9da4ee0f2",
     "packages": [
         {
             "name": "blueimp/jquery-file-upload",
@@ -340,62 +340,6 @@
                 "util"
             ],
             "time": "2015-10-16T14:27:39+00:00"
-        },
-        {
-            "name": "composer/ca-bundle",
-            "version": "1.2.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "95c63ab2117a72f48f5a55da9740a3273d45b7fd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/95c63ab2117a72f48f5a55da9740a3273d45b7fd",
-                "reference": "95c63ab2117a72f48f5a55da9740a3273d45b7fd",
-                "shasum": ""
-            },
-            "require": {
-                "ext-openssl": "*",
-                "ext-pcre": "*",
-                "php": "^5.3.2 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8",
-                "psr/log": "^1.0",
-                "symfony/process": "^2.5 || ^3.0 || ^4.0 || ^5.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\CaBundle\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
-            "keywords": [
-                "cabundle",
-                "cacert",
-                "certificate",
-                "ssl",
-                "tls"
-            ],
-            "time": "2020-04-08T08:27:21+00:00"
         },
         {
             "name": "datatables/datatables",
@@ -3517,59 +3461,6 @@
             "time": "2020-01-28T05:01:22+00:00"
         },
         {
-            "name": "sensio/distribution-bundle",
-            "version": "v5.0.25",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sensiolabs/SensioDistributionBundle.git",
-                "reference": "80a38234bde8321fb92aa0b8c27978a272bb4baf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioDistributionBundle/zipball/80a38234bde8321fb92aa0b8c27978a272bb4baf",
-                "reference": "80a38234bde8321fb92aa0b8c27978a272bb4baf",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.9",
-                "sensiolabs/security-checker": "~5.0|~6.0",
-                "symfony/class-loader": "~2.3|~3.0",
-                "symfony/config": "~2.3|~3.0",
-                "symfony/dependency-injection": "~2.3|~3.0",
-                "symfony/filesystem": "~2.3|~3.0",
-                "symfony/http-kernel": "~2.3|~3.0",
-                "symfony/process": "~2.3|~3.0"
-            },
-            "type": "symfony-bundle",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Sensio\\Bundle\\DistributionBundle\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                }
-            ],
-            "description": "Base bundle for Symfony Distributions",
-            "keywords": [
-                "configuration",
-                "distribution"
-            ],
-            "abandoned": true,
-            "time": "2019-06-18T15:43:58+00:00"
-        },
-        {
             "name": "sensio/framework-extra-bundle",
             "version": "v3.0.29",
             "source": {
@@ -3693,53 +3584,6 @@
             "description": "This bundle generates code for you",
             "abandoned": "symfony/maker-bundle",
             "time": "2017-12-07T15:36:41+00:00"
-        },
-        {
-            "name": "sensiolabs/security-checker",
-            "version": "v5.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sensiolabs/security-checker.git",
-                "reference": "46be3f58adac13084497961e10eed9a7fb4d44d1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/security-checker/zipball/46be3f58adac13084497961e10eed9a7fb4d44d1",
-                "reference": "46be3f58adac13084497961e10eed9a7fb4d44d1",
-                "shasum": ""
-            },
-            "require": {
-                "composer/ca-bundle": "^1.0",
-                "php": ">=5.5.9",
-                "symfony/console": "~2.7|~3.0|~4.0"
-            },
-            "bin": [
-                "security-checker"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "SensioLabs\\Security\\": "SensioLabs/Security"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien.potencier@gmail.com"
-                }
-            ],
-            "description": "A security checker for your composer.lock",
-            "abandoned": "https://github.com/fabpot/local-php-security-checker",
-            "time": "2018-12-19T17:14:59+00:00"
         },
         {
             "name": "setasign/fpdf",
@@ -5537,6 +5381,62 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "composer/ca-bundle",
+            "version": "1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/ca-bundle.git",
+                "reference": "95c63ab2117a72f48f5a55da9740a3273d45b7fd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/95c63ab2117a72f48f5a55da9740a3273d45b7fd",
+                "reference": "95c63ab2117a72f48f5a55da9740a3273d45b7fd",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "ext-pcre": "*",
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8",
+                "psr/log": "^1.0",
+                "symfony/process": "^2.5 || ^3.0 || ^4.0 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\CaBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
+            "keywords": [
+                "cabundle",
+                "cacert",
+                "certificate",
+                "ssl",
+                "tls"
+            ],
+            "time": "2020-04-08T08:27:21+00:00"
+        },
         {
             "name": "ircmaxell/password-compat",
             "version": "v1.0.4",

--- a/application/web/app.php
+++ b/application/web/app.php
@@ -2,7 +2,6 @@
 
 use Symfony\Component\HttpFoundation\Request;
 $loader = require_once(__DIR__ . '/../app/autoload.php');
-require_once __DIR__.'/../app/bootstrap.php.cache';
 
 require_once __DIR__.'/../app/AppKernel.php';
 

--- a/application/web/app_dev.php
+++ b/application/web/app_dev.php
@@ -2,8 +2,6 @@
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Debug\Debug;
-require_once(dirname(__FILE__) . '/../src/ComposerBootstrap.php');
-$usePrebuilt = ComposerBootstrap::isWindows();
 
 // If you don't want to setup permissions the proper way, just uncomment the following PHP line
 // read http://symfony.com/doc/current/book/installation.html#configuration-and-setup for more information
@@ -20,9 +18,6 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
 }
 
 $loader = require_once(__DIR__ . '/../app/autoload.php');
-if ($usePrebuilt) {
-    require_once __DIR__.'/../app/bootstrap.php.cache';
-}
 Debug::enable();
 
 require_once __DIR__.'/../app/AppKernel.php';

--- a/application/web/app_test.php
+++ b/application/web/app_test.php
@@ -18,7 +18,6 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
 }
 
 $loader = require_once(__DIR__ . '/../app/autoload.php');
-require_once __DIR__.'/../app/bootstrap.php.cache';
 require_once __DIR__.'/../app/AppKernel.php';
 
 use Symfony\Component\HttpFoundation\Request;

--- a/bootstrap
+++ b/bootstrap
@@ -2,7 +2,6 @@
 
 cd application
 php bin/composer install -o --no-scripts --no-suggest
-php bin/composer run build-bootstrap
 php bin/composer init-example
 php app/console assets:install --symlink --relative
 php app/console mapbender:database:init -v

--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -1,6 +1,5 @@
 cd application
 php bin/composer install -o --no-scripts --no-suggest
-php bin/composer run build-bootstrap
 php bin/composer init-example
 php app/console assets:install
 php app/console mapbender:database:init -v


### PR DESCRIPTION
Removes root requirement for [sensio/distribution-bundle](https://packagist.org/packages/sensio/distribution-bundle) and collateral (zero current function) [sensiolabs/security-checker](https://packagist.org/packages/sensiolabs/security-checker).

Both packages are abandoned.
For distribution-bundle:
> This package is abandoned and no longer maintained. No replacement package was suggested.

For security-checker:
> WARNING: Don't use this piece of software anymore as the underlying web service will stop working at the end of January 2021

This removal has zero functional impact on the running system. The only outward visible effect is that web/config.php can no longer be generated.

However, this removal from Mapbender Starter requires a simultaneous removal from Mapbender's BaseKernel (with no functional impact whatsoever). See [commit bf46f37](https://github.com/mapbender/mapbender/commit/bf46f372252758c8c344c48ff66c67b6992544e7). This removal is not yet part of any tagged Mapbender release. Performing the Mapbender Starter removal can only be done safely at the time of Mapbender release.

