### PR TITLE
Bypass app_dev.php localhost restriction with MB_EXPOSE_DEV environment

### DIFF
--- a/application/web/app_dev.php
+++ b/application/web/app_dev.php
@@ -9,10 +9,10 @@ use Symfony\Component\Debug\Debug;
 
 // This check prevents access to debug front controllers that are deployed by accident to production servers.
 // Feel free to remove this, extend it, or make something more sophisticated.
-if (isset($_SERVER['HTTP_CLIENT_IP'])
+if (!getenv('MB_EXPOSE_DEV') && (isset($_SERVER['HTTP_CLIENT_IP'])
    || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
    || !in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1'))
-) {
+)) {
    header('HTTP/1.0 403 Forbidden');
    exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
 }


### PR DESCRIPTION
Allows deliberate deactivation of the localhost-only access restriction hard-coded into app_dev.php.

If environment variable `MB_EXPOSE_DEV` is set, and has any value PHP considers true (i.e. any non-empty string except "0"), no access check is performed, and app_dev.php is accessible from any remote host.

If environment varialbe `MB_EXPOSE_DEV` is not set, set to the empty string or set to `0`, access remains restricted.