### PR TITLE
Improve parameters.yaml, add index_dev.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ cd mapbender-starter
 The bootstrap command performs the following required setup tasks for you:
 * installs userland dependencies (via composer)
 * creates a parameters.yaml by copying the bundled parameters.yml.dist
+* creates a .env.local file by copying the bundled .env.local.dist
 * performs the necessary database setup (as an sqlite file in `application/var/db/demo.sqlite`)
 * creates a root account with a default password `root` (which you should change later)
 
@@ -108,9 +109,12 @@ The environment can be set via the APP_ENV environment variable. The default is 
 your application in the internet. The value can be changed in several ways:
 
 - by editing `APP_ENV` in the `.env` file
-- by adding a `.env.local` file and overriding the value there
+- by overriding the value in a `.env.local` file
 - by explicitly setting it when starting the local webserver: `APP_ENV=prod symfony server:start --no-tls`
 - by setting an environment variable in your Apache2 vHost configuration: `SetEnv APP_ENV prod`
+
+The `index_dev.php` file allows direct access to the dev environment. It can only be accessed from local 
+ip addresses by default for security reasons.
 
 ## Changing root account password
 From the application directory run:

--- a/application/.env
+++ b/application/.env
@@ -15,21 +15,23 @@
 # https://symfony.com/doc/current/best_practices.html#use-environment-variables-for-infrastructure-configuration
 
 ###> symfony/framework-bundle ###
-APP_ENV=dev
-APP_SECRET=717dcaaeeec2968737aa8d09eeec61d4
+APP_ENV=prod
+APP_SECRET=ThisIsNotSoSecretChangeIt
 ###< symfony/framework-bundle ###
 
 ###> symfony/mailer ###
-# MAILER_DSN=null://null
+# MAILER_DSN=smtp://user:pass@smtp.example.com:25
+MAILER_DSN=null://null
 ###< symfony/mailer ###
 
 ###> doctrine/doctrine-bundle ###
 # Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
 # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
 #
-# DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
-# DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=8&charset=utf8mb4"
-DATABASE_URL="postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=15&charset=utf8"
+MAPBENDER_DATABASE_URL="sqlite:///%kernel.project_dir%/var/db/demo.sqlite"
+# uncomment this if you have multiple databases, e.g. for search or digitizer, and add a configuration in config/packages/doctrine.yaml
+# by duplicating the default configuration and adapting the env variable
+# SEARCH_DB_DATABASE_URL="postgresql://dbuser:dbpassword@localhost:5432/dbname?serverVersion=14&charset=utf8"
 ###< doctrine/doctrine-bundle ###
 
 ###> mapbender/mapbender ###

--- a/application/.env.local.dist
+++ b/application/.env.local.dist
@@ -1,0 +1,7 @@
+# overwrite these variables in your non-committed .env.local file if required (see .env for documentation)
+
+# MAILER_DSN=smtp://user:pass@smtp.example.com:25
+# APP_ENV=dev
+# APP_SECRET=ThisIsNotSoSecretChangeIt
+# MAPBENDER_DATABASE_URL="postgresql://dbuser:dbpassword@localhost:5432/dbname?serverVersion=14&charset=utf8"
+# SEARCH_DB_DATABASE_URL="postgresql://dbuser:dbpassword@localhost:5432/dbname?serverVersion=14&charset=utf8"

--- a/application/bin/ComposerBootstrap.php
+++ b/application/bin/ComposerBootstrap.php
@@ -40,18 +40,20 @@ class ComposerBootstrap
     }
 
     /**
-     * @return bool true if config file needed to be created
+     * @return bool true if a config file needed to be created
      */
-    protected static function ensureConfig()
+    protected static function ensureConfig(): bool
     {
-        $configPath = static::getParametersPath();
+        $files = [static::getParametersPath(), static::getLocalEnvFilePath()];
 
-        if (!file_exists($configPath)) {
-            copy("{$configPath}.dist", $configPath);
-            return true;
-        } else {
-            return false;
+        $fileCreated = false;
+        foreach ($files as $file) {
+            if (!file_exists($file)) {
+                copy("{$file}.dist", $file);
+                $fileCreated = true;
+            }
         }
+        return $fileCreated;
     }
 
     /**
@@ -451,6 +453,11 @@ class ComposerBootstrap
     protected static function getParametersPath()
     {
         return static::getSymfonyRootPath() . '/config/parameters.yaml';
+    }
+
+    protected static function getLocalEnvFilePath()
+    {
+        return static::getSymfonyRootPath() . '/.env.local';
     }
 
     /**

--- a/application/composer.lock
+++ b/application/composer.lock
@@ -1548,12 +1548,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mapbender/mapbender-digitizer.git",
-                "reference": "b3e80618d097edd44fdb96d4f3e1906c49b5d959"
+                "reference": "9f673bb15fed57c26ef74a05460860d54da5e199"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mapbender/mapbender-digitizer/zipball/b3e80618d097edd44fdb96d4f3e1906c49b5d959",
-                "reference": "b3e80618d097edd44fdb96d4f3e1906c49b5d959",
+                "url": "https://api.github.com/repos/mapbender/mapbender-digitizer/zipball/9f673bb15fed57c26ef74a05460860d54da5e199",
+                "reference": "9f673bb15fed57c26ef74a05460860d54da5e199",
                 "shasum": ""
             },
             "require": {
@@ -1615,7 +1615,7 @@
                 "issues": "https://github.com/mapbender/mapbender-digitizer/issues",
                 "source": "https://github.com/mapbender/mapbender-digitizer/tree/develop"
             },
-            "time": "2023-10-30T15:56:27+00:00"
+            "time": "2024-02-07T09:34:43+00:00"
         },
         {
             "name": "mapbender/mapbender",
@@ -1623,12 +1623,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mapbender/mapbender.git",
-                "reference": "e284b46ac5fbb67a7604fe53992776dbd71da380"
+                "reference": "620a67ed3ae2bea22acfd0c734da0fb80fd60c27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mapbender/mapbender/zipball/e284b46ac5fbb67a7604fe53992776dbd71da380",
-                "reference": "e284b46ac5fbb67a7604fe53992776dbd71da380",
+                "url": "https://api.github.com/repos/mapbender/mapbender/zipball/620a67ed3ae2bea22acfd0c734da0fb80fd60c27",
+                "reference": "620a67ed3ae2bea22acfd0c734da0fb80fd60c27",
                 "shasum": ""
             },
             "require": {
@@ -1753,7 +1753,7 @@
                 "issues": "https://github.com/mapbender/mapbender/issues",
                 "source": "https://github.com/mapbender/mapbender/tree/develop"
             },
-            "time": "2023-11-09T10:41:19+00:00"
+            "time": "2024-02-07T14:15:37+00:00"
         },
         {
             "name": "mapbender/mapbender-icons",

--- a/application/config/packages/doctrine.yaml
+++ b/application/config/packages/doctrine.yaml
@@ -3,13 +3,7 @@ doctrine:
         default_connection: default
         connections:
             default:
-                driver:   '%database_driver%'
-                host:     '%database_host%'
-                port:     '%database_port%'
-                dbname:   '%database_name%'
-                path:     '%database_path%'
-                user:     '%database_user%'
-                password: '%database_password%'
+                url: '%env(resolve:MAPBENDER_DATABASE_URL)%'
                 persistent: true
                 charset:  UTF8
                 logging: '%kernel.debug%'

--- a/application/config/packages/mailer.yaml
+++ b/application/config/packages/mailer.yaml
@@ -1,3 +1,4 @@
 framework:
     mailer:
-        dsn: '%mailer_dsn%'
+        dsn: '%env(MAILER_DSN)%'
+

--- a/application/config/parameters.yaml.dist
+++ b/application/config/parameters.yaml.dist
@@ -1,26 +1,18 @@
+# Documentation: https://docs.mapbender.org/current/en/customization/yaml.html#parameters-yaml
+# Databases and mailer settings are no longer configured here. Use the .env file
+# Also see config/packages/fom.yaml for user-management-specific configuration
+
 parameters:
-    ### todo: switch to using dsn urls, see https://www.doctrine-project.org/projects/doctrine-dbal/en/2.9/reference/configuration.html#connecting-using-a-url
-    ###       To avoid suprises, a DSN can be constructed here from parts, at least for the shipping default parameters
-    ###       Connection definition in config.yaml should only use url: '%database_dsn%' though
-    database_driver:   pdo_sqlite
-    database_host:     ~
-    database_port:     ~
-    database_name:     ~
-    database_path:     '%kernel.project_dir%/var/db/demo.sqlite'
-    database_user:     ~
-    database_password: ~
-
-    # Might also use third-party providers like e.g. Mailchimp, see https://symfony.com/doc/current/mailer.html#using-built-in-transports
-    mailer_dsn:        smtp://user:pass@smtp.example.com:25
-
-    # locale en, de, it, es, ru, nl, pt are available
+    # locale en, de, es, fr, it, nl, pt, ru, tr, uk are available
     fallback_locale:   en
     locale:            en
-    secret:            ThisTokenIsNotSoSecretChangeIt
+    # uncomment this if you don't want the language to automatically adapt to the browser language
+    # mapbender.automatic_locale: false
 
-    # framework : https://symfony.com/doc/4.4/reference/configuration/framework.html#cookie-lifetime
+    # framework : https://symfony.com/doc/6.4/reference/configuration/framework.html#cookie-lifetime
     cookie_secure: false
     cookie_lifetime: 3600
+    log_path: '%kernel.logs_dir%/%kernel.environment%.log'
 
     # OWSProxy Configuration
     # see https://github.com/mapbender/owsproxy3/blob/master/CONFIGURATION.md#extension-configuration
@@ -33,3 +25,27 @@ parameters:
     ows_proxy3_user: ~
     ows_proxy3_password: ~
     ows_proxy3_noproxy: ~
+
+    # Custom Branding
+    # branding.project_name: Geoportal powered by Mapbender
+    # branding.logo: ./bundles/mapbendercore/image/OSGeo_project.png
+    # branding.login_backdrop: https://mapbender.org/fileadmin/mapbender/resources/images/startseite/mapbender-stadt-markierungen.jpg
+    # branding.login_backdrop_hq: https://mapbender.org/fileadmin/mapbender/resources/images/startseite/mapbender-stadt-markierungen.jpg
+    # branding.splashscreen_image: bundles/mapbendercore/image/OSGeo_project.png
+    # mapbender.sitelinks:
+    #    - link: https://mapbender.org/
+    #      text: Mapbender.org
+    #    - link: https://mapbender.org/en/showcase/
+    #      text: Gallery
+
+
+    # disabled elements are not available throughout the application
+    # mapbender.disabled_elements:
+    #     - Mapbender\CoreBundle\Element\ResetView
+
+    # default layer order when creating *new* WMS layerset instances
+    # allowed values are either
+    # * "standard": Traditional Mapbender behaviour: top-down rendering in GetCapabilities order;
+    #               also the default if this parameter is not defined
+    # * "reverse": bottom-up, for QGIS server, ArcGIS etc
+    # wms.default_layer_order: standard

--- a/application/config/services.yaml
+++ b/application/config/services.yaml
@@ -1,22 +1,6 @@
 # This file is the entry point to configure your own services.
 # Files in the packages/ subdirectory configure your dependencies.
 
-# Put parameters here that don't need to change on each machine where the app is deployed
-# https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
-parameters:
-    log_path: '%kernel.logs_dir%/%kernel.environment%.log'
-    mapbender.disabled_elements:
-        - Mapbender\CoreBundle\Element\ResetView
-        # Installed as a collateral Digitizer 1.4 dependency
-        - Mapbender\DataManagerBundle\Element\DataManager
-    # default layer order when creating *new* WMS layerset instances
-    # allowed values are either
-    # * "standard": Traditional Mapbender behaviour: top-down rendering in GetCapabilities order;
-    #               also the default if this parameter is not defined
-    # * "reverse": bottom-up, for QGIS server, ArcGIS etc
-    # wms.default_layer_order: standard
-
-
 services:
     # default configuration for services in *this* file
     _defaults:

--- a/application/public/index_dev.php
+++ b/application/public/index_dev.php
@@ -1,0 +1,20 @@
+<?php
+
+use App\Kernel;
+
+// This check prevents access to debug front controllers that are deployed by accident to production servers.
+// Feel free to remove this, extend it, or make something more sophisticated.
+if (!getenv('MB_EXPOSE_DEV') && (isset($_SERVER['HTTP_CLIENT_IP'])
+   || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
+   || !in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1'))
+)) {
+   header('HTTP/1.0 403 Forbidden');
+   exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
+}
+
+
+require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
+
+return function (array $context) {
+    return new Kernel('dev', (bool) $context['APP_DEBUG']);
+};


### PR DESCRIPTION
- Improve inline documentation for parameters.yaml: fixes #1498
- Extract mailer_dsn and database urls into .env file to follow symfony default behaviour
- added index_dev.php for easy local access to the development environment