### PR TITLE
Develop docker adjustments

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,8 +2,6 @@ name: Build and push release Docker image
 
 on:
   push:
-    branches:
-      - "master"
     tags:
       - "v*"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,6 @@ COPY --chown=www-data:www-data . /var/mapbender/
 # required to create a complete mapbender application container image including all dependencies
 RUN ./bootstrap
 
+EXPOSE 8080
+
 CMD ["apache2-foreground"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ ENV APACHE_DOCUMENT_ROOT /var/mapbender/application/public
 
 RUN apt-get update && apt-get install -y \
         libpq-dev \
-        git \
         vim \
         unzip \
         openssl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM php:8.3-apache
+FROM php:8.3-apache as base-container
 
 ENV APACHE_DOCUMENT_ROOT /var/mapbender/application/public
 
 RUN apt-get update && apt-get install -y \
         libpq-dev \
-        vim \
         unzip \
         openssl \
         bzip2 \
@@ -19,7 +18,8 @@ RUN apt-get update && apt-get install -y \
         libsqlite3-dev \
         libldap2-dev \
         libonig-dev \
-        postgresql-client
+        postgresql-client \
+        && rm -rf /var/lib/apt/lists/*
 
 RUN docker-php-ext-install pdo_pgsql
 RUN docker-php-ext-install curl gd intl mbstring zip bz2 xml pdo_sqlite ldap
@@ -33,15 +33,27 @@ RUN a2enmod rewrite remoteip
 
 RUN chown www-data:www-data -R /var/www
 
-USER www-data
-
 WORKDIR /var/mapbender/
+
+EXPOSE 8080
 
 COPY --chown=www-data:www-data . /var/mapbender/
 
+FROM base-container as build-container
+
+RUN apt-get update && apt-get install -y \
+        git \
+        && rm -rf /var/lib/apt/lists/*
+
+USER www-data
 # required to create a complete mapbender application container image including all dependencies
 RUN ./bootstrap
 
-EXPOSE 8080
+
+FROM base-container
+
+USER www-data
+
+COPY --from=build-container --chown=www-data:www-data /var/mapbender /var/mapbender
 
 CMD ["apache2-foreground"]


### PR DESCRIPTION
This PR adds:

- EXPOSE 8080 to Dockerfile which is for intent documentation purposes only but required to make docker desktop provide the form field to configure the host port mapping for port 8080
- change Dockerfile to a multi-stage-build to remove git (flagged to have critical severity vulnerability https://scout.docker.com/v/CVE-2024-32002) from the resulting docker image
- remove branches gh action condition as it is only supposed to run for tagged commits