### PR TITLE
add platform linux/arm64 to docker/build-push gh action

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -29,7 +29,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         context: .
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: |
           mapbender/mapbender:latest


### PR DESCRIPTION
This PR will add the feature to create ARM based container images for each docker release in addition to the existing x86 image.

The resulting image was successfully tested on a raspberry pi 3 b+.