### PR TITLE
Ignore deprecation notices in production logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## next bugfix release (4.0.1)
+- [Docker] Support ARM64 architecture ([PR#130](https://github.com/mapbender/mapbender-starter/pull/130))
+- Ignore deprecation notices in production logs ([PR#131](https://github.com/mapbender/mapbender-starter/pull/131))
+
 ## v4.0.0
 - PHP 8.2 and 8.3 now fully supported, minimum required PHP version is now 8.1
 - Update mapbender/mapbender to [v4.0](https://github.com/mapbender/mapbender/blob/v4.0.0/CHANGELOG.md). 

--- a/application/config/packages/monolog.yaml
+++ b/application/config/packages/monolog.yaml
@@ -50,13 +50,9 @@ when@prod:
                 type: stream
                 path: php://stderr
                 level: debug
+                channels: ["!deprecation"]
                 formatter: monolog.formatter.json
             console:
                 type: console
                 process_psr_3_messages: false
                 channels: ["!event", "!doctrine"]
-            deprecation:
-                type: stream
-                channels: [deprecation]
-                path: php://stderr
-                formatter: monolog.formatter.json


### PR DESCRIPTION
in most cases, deprecation notices are not relevant in production logs, but instead they use up a lot of space and make spotting actual warnings and errors more difficult.

if you need to log deprecations in your specific environment, just change the setting back in your monolog.yaml file.