### PR TITLE
Fix API usage: authorization token / bearer will be forwarded by Apache to PHP

### DIFF
--- a/docker/mapbender_apache.conf
+++ b/docker/mapbender_apache.conf
@@ -13,6 +13,8 @@ RemoteIPHeader X-Forwarded-For
 
         Require all granted
 
+        SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+
         RewriteEngine On
         RewriteBase /
         # If using mapbender behind an reverse-proxy


### PR DESCRIPTION
The API could only be used for the first login in the Docker environment. All subsequent, correct API calls failed because the JWT token was not found. The following error message appeared:

```
{
  "code": 401,
  "message": "JWT Token not found"
}
```

- By default, Apache does not always forward the Authorization header to CGI/Mod-PHP for security reasons. This line ensures that it is forwarded.
- This directive checks whether an `Authorization` header is present in the incoming HTTP request.
- If the header exists, its entire content (via `(.*)`) is extracted and written to an environment variable called `HTTP_AUTHORIZATION`.