### PR TITLE
Ask for password instead of defaulting to root in bootstrap script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
-## v5.0.0-RC1
+## next major release
 - Minimum required PHP version is now 8.2
 - Updated Symfony to version 7.4, refer to the mapbender core repository for ([upgrade instructions](https://github.com/mapbender/mapbender/blob/v5.0.0-RC1/docs/UPGRADING.md))
 - Update mapbender/mapbender to [v5.0.0-RC1](https://github.com/mapbender/mapbender/blob/v5.0.0-RC1/CHANGELOG.md).
 - Update mapbender/digitizer to [3.0.0-RC1](https://github.com/mapbender/mapbender-digitizer/blob/3.0.0-RC1/CHANGELOG.md).
 - Add OgcApiFeatureBundle to [v5.0.0](https://github.com/mapbender/mapbender-starter/pull/165).
 - Update Openlayers to [10.9](https://github.com/openlayers/openlayers/releases/tag/v10.9.0)
+- Ask for password instead of defaulting to root in bootstrap script ([PR#173](https://github.com/mapbender/mapbender-starter/pull/173))
 
 ## v4.2.6
 - Update mapbender/mapbender to [v4.2.6](https://github.com/mapbender/mapbender/blob/v4.2.6/CHANGELOG.md).

--- a/application/bin/ComposerBootstrap.php
+++ b/application/bin/ComposerBootstrap.php
@@ -2,16 +2,17 @@
 
 use Composer\Script\Event;
 
+/**
+ * PHP file for the scripts called in the scripts section of composer.json
+ * for IDE support, execute `composer require --dev composer/composer`
+ */
 class ComposerBootstrap
 {
-    /**
-     * @param $event Event
-     */
-    public static function checkConfiguration($event)
+    public static function checkConfiguration(Event $event)
     {
         if (static::ensureConfig()) {
             static::createDatabase();
-            static::resetRootLogin();
+            static::resetRootLogin($event);
             static::importExampleApplications();
             static::updateEpsgCodes();
         }
@@ -19,17 +20,14 @@ class ComposerBootstrap
         static::clearCache();
     }
 
-    /**
-     * @param $event Event
-     */
-    public static function bootstrapDatabase($event)
+    public static function bootstrapDatabase(Event $event)
     {
         static::ensureConfig();
         $status = null;
         passthru("php bin/console doctrine:schema:create", $status);
         if ($status === 0) {
             `php bin/console mapbender:database:init -v`;
-            static::resetRootLogin();
+            static::resetRootLogin($event);
         }
     }
 
@@ -59,15 +57,13 @@ class ComposerBootstrap
     /**
      * Rebuild database.
      * Needs for tests
-     *
-     * @param $event
      */
-    public static function rebuildDatabase($event)
+    public static function rebuildDatabase(Event $event)
     {
         static::ensureConfig();
         static::dropDatabase();
         static::createDatabase();
-        static::resetRootLogin();
+        static::resetRootLogin($event);
         static::importExampleApplications();
         static::updateEpsgCodes();
         //static::clearCache();
@@ -171,25 +167,23 @@ class ComposerBootstrap
         //echo `php bin/console doctrine:schema:update --force`;
     }
 
-    /**
-     * Reset root user login
-     *
-     * @param string $userName
-     * @param string $password
-     * @param string $userEmail
-     */
-    protected static function resetRootLogin($userName = "root", $password = "root", $userEmail = "root@localhost")
+    protected static function resetRootLogin(Event $event)
     {
-        $userName = escapeshellarg($userName);
-        $userEmail = escapeshellarg($userEmail);
-        $password = escapeshellarg($password);
+        $userName = "root";
+        $userEmail = "root@localhost";
 
         static::printStatus("Reset user password");
 
-        `php bin/console fom:user:resetroot --username $userName --password $password --email $userEmail --silent`;
+        $command = "php bin/console fom:user:resetroot --username $userName --email $userEmail";
 
-        static::printStatus("ATTENTION");
-        echo "User $userName account password is: $password. Don't forget to change it!\n";
+        $flags = $event->getFlags();
+        foreach(['--generate-password', '--no-interaction'] as $flagToForward) {
+            if (isset($flags["script-alias-input"]) && str_contains($flags["script-alias-input"], $flagToForward)) {
+                $command .= " $flagToForward";
+            }
+        }
+
+        echo `$command`;
     }
 
     /**

--- a/bootstrap
+++ b/bootstrap
@@ -2,7 +2,7 @@
 
 cd application
 php bin/composer install -o --no-scripts --no-suggest
-php bin/composer init-example
+php bin/composer init-example $@
 php bin/console assets:install --symlink --relative
 php bin/console mapbender:database:init -v
 if ! grep -q "JWT_PASSPHRASE=" .env.local; then

--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -1,6 +1,6 @@
 cd application
 php bin/composer install -o --no-scripts --no-suggest
-php bin/composer init-example
+php bin/composer init-example %*
 php bin/console assets:install
 php bin/console mapbender:database:init -v
 findstr /B /C:"JWT_PASSPHRASE=" .env.local >nul 2>&1


### PR DESCRIPTION
Instead of always defaulting to root:root, the bootstrap script will now ask for the root password when executed by default.

There are also additional ways to set the password (that also work in automated, non-interactive environments):


- Use the flag `--generate-password` to automatically generate a 12-digit passwort with alphanumeric digits/letters and commmon special chars. It will be displayed to stdout.

```bash
./bootstrap --no-interaction
```

- Use the env variable `MAPBENDER_ROOT_PASSWORD` to set the root password

```bash
MAPBENDER_ROOT_PASSWORD=verySafePassword ./bootstrap
```


- Use the flag `--no-interaction` to continue defaulting to root (not recommended)

```bash
./bootstrap --no-interaction
```


Related PR: https://github.com/mapbender/mapbender/pull/1889